### PR TITLE
Fixed Rust feature rename

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![feature(plugin,try_from,custom_derive)]
-#![feature(proc_macro_gen)]
+#![feature(proc_macro_hygiene)]
 #![plugin(rocket_codegen)]
 extern crate rocket;
 #[macro_use] extern crate rocket_contrib;


### PR DESCRIPTION
Some update to Rust nightly renamed a feature, this was needed for me to get it to compile.

(Also my first contribution to aw-server-rust :tada:)