### PR TITLE
Externalize datastore lock

### DIFF
--- a/src/endpoints/import.rs
+++ b/src/endpoints/import.rs
@@ -17,7 +17,7 @@ pub enum ImportFormat {
 #[post("/", data = "<json_data>", format = "application/json")]
 pub fn bucket_import(state: State<ServerState>, json_data: Json<ImportFormat>) -> Result<(), Status> {
     match json_data.into_inner() {
-        ImportFormat::Single(bucket) => match state.datastore.create_bucket(&bucket) {
+        ImportFormat::Single(bucket) => match endpoints_get_lock!(state.datastore).create_bucket(&bucket) {
             Ok(_) => (),
             Err(e) => {
                 warn!("Failed to import bucket: {:?}", e);
@@ -26,7 +26,7 @@ pub fn bucket_import(state: State<ServerState>, json_data: Json<ImportFormat>) -
         },
         ImportFormat::Multiple(buckets) => {
             for (_bucketname, bucket) in buckets {
-                match state.datastore.create_bucket(&bucket) {
+                match endpoints_get_lock!(state.datastore).create_bucket(&bucket) {
                     Ok(_) => (),
                     Err(e) => {
                         warn!("Failed to import bucket: {:?}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,8 @@ pub mod dirs;
 pub mod logging;
 
 fn main() {
-    use std::path::{PathBuf};
+    use std::path::PathBuf;
+    use std::sync::Mutex;
 
     logging::setup_logger().expect("Failed to setup logging");
 
@@ -42,7 +43,7 @@ fn main() {
     info!("Using DB at path {:?}", db_path);
 
     let server_state = endpoints::ServerState {
-        datastore: datastore::Datastore::new(db_path),
+        datastore: Mutex::new(datastore::Datastore::new(db_path)),
         asset_path: PathBuf::from("aw-webui").join("dist"),
     };
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -7,7 +7,8 @@ extern crate aw_server;
 
 #[cfg(test)]
 mod api_tests {
-    use std::path::{PathBuf};
+    use std::path::PathBuf;
+    use std::sync::Mutex;
     use rocket::http::ContentType;
 
     use aw_server::datastore;
@@ -15,7 +16,7 @@ mod api_tests {
 
     fn setup_testserver() -> rocket::Rocket {
         let state = endpoints::ServerState {
-            datastore: datastore::Datastore::new_in_memory(),
+            datastore: Mutex::new(datastore::Datastore::new_in_memory()),
             asset_path: PathBuf::from("aw-webui/dist"),
         };
         endpoints::rocket(state, None)


### PR DESCRIPTION
Makes it possible to clone the Datastore producer object.
This will make it possible for the android code to both have the Web API running at the same time as we do other requests to the datastore. Will also probably make it easier to implement sync later on as that would probably run in its own thread and also need access to the datastore.

An example would be:
```
let datastore = datastore::Datastore::new_in_memory();
let state = endpoints::ServerState {
    datastore: Mutex::new(datastore.clone()),
    asset_path: PathBuf::from("aw-webui/dist"),
};
endpoints::rocket(state, None)
// Do other stuff with the original datastore object
```
