### PR TITLE
datastore: Add 'data' field to buckets table

### DIFF
--- a/src/models/bucket.rs
+++ b/src/models/bucket.rs
@@ -1,6 +1,7 @@
 use chrono::DateTime;
 use chrono::Utc;
 use std::collections::HashMap;
+use serde_json::value::Value;
 
 use crate::models::Event;
 
@@ -15,6 +16,8 @@ pub struct Bucket {
     pub client: String,
     pub hostname: String,
     pub created: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub data: Value,
     pub events: Option<Vec<Event>>,
 }
 

--- a/tests/datastore.rs
+++ b/tests/datastore.rs
@@ -28,6 +28,7 @@ mod datastore_tests {
             client: "testclient".to_string(),
             hostname: "testhost".to_string(),
             created: Some(Utc::now()),
+            data: json!("{}"),
             events: None
         };
         ds.create_bucket(&bucket).unwrap();

--- a/tests/models.rs
+++ b/tests/models.rs
@@ -27,6 +27,7 @@ mod models_tests {
             client: "client".to_string(),
             hostname: "hostname".to_string(),
             created: None,
+            data: json!("{}"),
             events: None
         };
         debug!("bucket: {:?}", b);

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -34,6 +34,7 @@ mod query_tests {
             client: "testclient".to_string(),
             hostname: "testhost".to_string(),
             created: Some(chrono::Utc::now()),
+            data: json!("{}"),
             events: None
         };
         ds.create_bucket(&bucket).unwrap();


### PR DESCRIPTION
Database migration is pretty simple when using "ALTER TABLE"