### PR TITLE
datastore: Added bucket metadata and removed external ReplaceLast API

### DIFF
--- a/src/models/bucket.rs
+++ b/src/models/bucket.rs
@@ -18,7 +18,25 @@ pub struct Bucket {
     pub created: Option<DateTime<Utc>>,
     #[serde(default)]
     pub data: Value,
+    #[serde(default, skip_deserializing)]
+    pub metadata: BucketMetadata,
     pub events: Option<Vec<Event>>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct BucketMetadata {
+    #[serde(default)]
+    pub start: Option<DateTime<Utc>>,
+    pub end: Option<DateTime<Utc>>,
+}
+
+impl Default for BucketMetadata {
+    fn default() -> BucketMetadata {
+        BucketMetadata {
+            start: None,
+            end: None,
+        }
+    }
 }
 
 #[derive(Clone,Serialize,Deserialize)]

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -5,6 +5,7 @@ mod timeinterval;
 mod query;
 
 pub use self::bucket::Bucket;
+pub use self::bucket::BucketMetadata;
 pub use self::bucket::BucketsExport;
 pub use self::event::Event;
 pub use self::timeinterval::TimeInterval;

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -5,6 +5,8 @@ extern crate rocket;
 
 extern crate aw_server;
 
+// TODO: Validate return data on more places
+
 #[cfg(test)]
 mod api_tests {
     use std::path::PathBuf;
@@ -16,7 +18,7 @@ mod api_tests {
     use aw_server::datastore;
     use aw_server::endpoints;
 
-    use aw_server::models::BucketsExport;
+    use aw_server::models::{Bucket, BucketsExport};
 
     fn setup_testserver() -> rocket::Rocket {
         let state = endpoints::ServerState {
@@ -86,6 +88,15 @@ mod api_tests {
             .dispatch();
         debug!("{:?}", res.body_string());
         assert_eq!(res.status(), rocket::http::Status::Ok);
+        // Validate output
+        let bucket : Bucket = serde_json::from_str(&res.body_string().unwrap()).unwrap();
+        assert_eq!(bucket.id, "id");
+        assert_eq!(bucket._type, "type");
+        assert_eq!(bucket.client, "client");
+        assert_eq!(bucket.hostname, "hostname");
+        assert_eq!(bucket.events, None);
+        assert_eq!(bucket.metadata.start, None);
+        assert_eq!(bucket.metadata.end, None);
 
         // Get non-existing bucket
         res = client.get("/api/0/buckets/invalid_bucket")

--- a/tests/models.rs
+++ b/tests/models.rs
@@ -15,6 +15,7 @@ mod models_tests {
     use chrono::Duration;
 
     use aw_server::models::Bucket;
+    use aw_server::models::BucketMetadata;
     use aw_server::models::Event;
     use aw_server::models::TimeInterval;
 
@@ -28,6 +29,7 @@ mod models_tests {
             hostname: "hostname".to_string(),
             created: None,
             data: json!("{}"),
+            metadata: BucketMetadata::default(),
             events: None
         };
         debug!("bucket: {:?}", b);

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -14,6 +14,7 @@ mod query_tests {
     use aw_server::query::DataType;
     use aw_server::datastore::Datastore;
     use aw_server::models::Bucket;
+    use aw_server::models::BucketMetadata;
     use aw_server::models::Event;
     use aw_server::models::TimeInterval;
 
@@ -35,6 +36,7 @@ mod query_tests {
             hostname: "testhost".to_string(),
             created: Some(chrono::Utc::now()),
             data: json!("{}"),
+            metadata: BucketMetadata::default(),
             events: None
         };
         ds.create_bucket(&bucket).unwrap();

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -33,7 +33,9 @@ mod transform_tests {
 
         // Merge result
         let res_merge = transform::heartbeat(&event1, &heartbeat1, 2.0).unwrap();
-        assert!(res_merge.duration == Duration::seconds(3));
+        assert_eq!(res_merge.timestamp, now);
+        assert_eq!(res_merge.duration, Duration::seconds(3));
+        assert_eq!(res_merge.data, event1.data);
 
         // No merge result
         let res_no_merge = transform::heartbeat(&event1, &heartbeat1, 0.0);


### PR DESCRIPTION
Solves #32 

The resulting data looks like this when doing a request over REST:

```
"metadata": {
    "first_starttime": "2018-01-01"
    "last_endtime": "2018-01-02"
}
```

If the bucket is empty:

```
"metadata": {
    "first_starttime": null
    "last_endtime": null
}
```