### PR TITLE
Make heartbeat requests respond with a merged heartbeat

### DIFF
--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -149,7 +149,7 @@ pub mod android {
             Err(err) => return create_error_object(&env, err.to_string())
         };
         match openDatastore().heartbeat(&bucket_id, event_json, pulsetime) {
-            Ok(()) => string_to_jstring(&env, "Heartbeat successfully received".to_string()),
+            Ok(_) => string_to_jstring(&env, "Heartbeat successfully received".to_string()),
             Err(e) => create_error_object(&env, format!("Something went wrong when trying to send heartbeat: {:?}", e))
         }
     }

--- a/src/endpoints/bucket.rs
+++ b/src/endpoints/bucket.rs
@@ -135,15 +135,15 @@ pub fn bucket_events_create(bucket_id: String, events: Json<Vec<Event>>, state: 
 }
 
 #[post("/<bucket_id>/heartbeat?<pulsetime>", data = "<heartbeat_json>")]
-pub fn bucket_events_heartbeat(bucket_id: String, heartbeat_json: Json<Event>, pulsetime: f64, state: State<ServerState>) -> Result<(), Status> {
+pub fn bucket_events_heartbeat(bucket_id: String, heartbeat_json: Json<Event>, pulsetime: f64, state: State<ServerState>) -> Result<Json<Event>, Status> {
     let heartbeat = heartbeat_json.into_inner();
     let datastore = endpoints_get_lock!(state.datastore);
     match datastore.heartbeat(&bucket_id, heartbeat, pulsetime) {
-        Ok(_) => Ok(()),
-        Err(e) => match e {
+        Ok(e) => Ok(Json(e)),
+        Err(err) => match err {
             DatastoreError::NoSuchBucket => Err(Status::NotFound),
-            e => {
-                warn!("Heartbeat failed: {:?}", e);
+            err => {
+                warn!("Heartbeat failed: {:?}", err);
                 Err(Status::InternalServerError)
             }
         }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -168,6 +168,7 @@ mod api_tests {
             .dispatch();
         debug!("{:?}", res.body_string());
         assert_eq!(res.status(), rocket::http::Status::Ok);
+        assert_eq!(res.body_string().unwrap(), r#"{"id":null,"timestamp":"2018-01-01T01:01:01Z","duration":2.0,"data":{}}"#);
 
         // Get heartbeat event
         res = client.get("/api/0/buckets/id/events")


### PR DESCRIPTION
aw-client-js expects to get a event body as a response when the request is 200 OK, aw-server-rust now responds with the same data as aw-server-python