### PR TITLE
datastore: Don't copy buckets events into bucket_cache during import

### DIFF
--- a/src/models/bucket.rs
+++ b/src/models/bucket.rs
@@ -21,7 +21,7 @@ pub struct Bucket {
     pub data: Map<String, Value>,
     #[serde(default, skip_deserializing)]
     pub metadata: BucketMetadata,
-    pub events: Option<Vec<Event>>,
+    pub events: Option<Vec<Event>>, /* Should only be set during import/export */
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]


### PR DESCRIPTION
Fixes https://github.com/ActivityWatch/aw-server-rust/issues/23