### PR TITLE
Add key value store

### DIFF
--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -599,7 +599,7 @@ impl DatastoreInstance {
         return Ok(count);
     }
 
-    pub fn create_value(&self, conn: &Connection, key: &str, data: &str)
+    pub fn insert_value(&self, conn: &Connection, key: &str, data: &str)
         -> Result<(), DatastoreError> {
 
         let mut stmt = match conn.prepare("

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -637,9 +637,9 @@ impl DatastoreInstance {
 
         return match stmt.query_row(&[key], |row|{
             Ok(KeyValue {
-                key: row.get(0).unwrap(), 
-                value: row.get(1).unwrap(), 
-                timestamp: DateTime::from_utc(NaiveDateTime::from_timestamp(row.get(2).unwrap(), 0), Utc)
+                key: row.get(0)?, 
+                value: row.get(1)?,
+                timestamp: DateTime::from_utc(NaiveDateTime::from_timestamp(row.get(2)?, 0), Utc)
             }
             )}) 
         {
@@ -667,12 +667,13 @@ impl DatastoreInstance {
         };
 
         let mut output = Vec::<String>::new();
-        // Unwrap to String or panic on SQL row if type is invalid.
-        // should never happen with a properly initialized table
+        // Rusqlite's get wants index and item type as parameters.
         let result = stmt.query_map(&[pattern], |row| row.get::<usize, String>(0));
         match result {
             Ok(keys) => {
                 for row in keys {
+                    // Unwrap to String or panic on SQL row if type is invalid. Can't happen with a
+                    // properly initialized table.
                     output.push(row.unwrap());
                 }
                 Ok(output)

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -610,7 +610,7 @@ impl DatastoreInstance {
                 format!("Failed to prepare insert_value SQL statement: {}", err)
             ))
         };
-        stmt.execute(&[key as &str, data as &str]).expect(
+        stmt.execute(&[key, data]).expect(
             &format!("Failed to insert key-value pair: {}", key)
         );
         return Ok(())
@@ -631,7 +631,7 @@ impl DatastoreInstance {
             ))
         };
 
-        return match stmt.query_row(&[key as &str], |row|{
+        return match stmt.query_row(&[key], |row|{
             row.get(1)
         }) {
             Ok(result)  => Ok(result),
@@ -644,9 +644,10 @@ impl DatastoreInstance {
         }
     }
 
-    pub fn get_values_starting(&self, conn: &Connection, pattern: &str) -> Result<HashMap<String, String>, DatastoreError>{
-        let mut stmt = match conn.prepare("
-                SELECT * FROM key_value WHERE pattern LIKE ?1%") {
+    pub fn get_values_starting(&self, conn: &Connection, pattern: &str) 
+        -> Result<HashMap<String, String>, DatastoreError>
+    {
+        let mut stmt = match conn.prepare("SELECT * FROM key_value WHERE key LIKE '.%' ") {
             Ok(stmt) => stmt,
             Err(err) => return Err(DatastoreError::InternalError(
                 format!("Failed to prepare get_value SQL statement: {}", err)
@@ -654,7 +655,7 @@ impl DatastoreInstance {
         };
 
         let mut output = HashMap::<String, String>::new();
-        let result = stmt.query(&[pattern as &str]);
+        let result = stmt.query(&[pattern]);
 
         match result {
             Ok(rows) => {

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -647,7 +647,7 @@ impl DatastoreInstance {
     pub fn get_keys_starting(&self, conn: &Connection, pattern: &str)
         -> Result<Vec<String>, DatastoreError>
     {
-        let mut stmt = match conn.prepare("SELECT key FROM key_value WHERE key LIKE '.%' ") {
+        let mut stmt = match conn.prepare("SELECT key FROM key_value WHERE key LIKE ?") {
             Ok(stmt) => stmt,
             Err(err) => {
                 return Err(DatastoreError::InternalError(format!(
@@ -658,13 +658,12 @@ impl DatastoreInstance {
         };
 
         let mut output = Vec::<String>::new();
-        // Unwrap to String tuple or panic on SQL row if types are invalid.
+        // Unwrap to String or panic on SQL row if type is invalid.
         // should never happen with a properly initialized table
         let result = stmt.query_map(&[pattern], |row| row.get::<usize, String>(0));
-
         match result {
-            Ok(kv_pairs) => {
-                for row in kv_pairs {
+            Ok(keys) => {
+                for row in keys {
                     output.push(row.unwrap());
                 }
                 Ok(output)

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -630,6 +630,7 @@ impl DatastoreInstance {
             ))
         };
         let result: String= stmt.query_row(&[key as &str], |row|{
+            // TODO: actually return a valid response if no value received
             row.get(0)
         }).expect(&"Invalid type value received from db query.");
 

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -636,7 +636,7 @@ impl DatastoreInstance {
         }) {
             Ok(result)  => Ok(result),
             Err(err) => match err {
-                rusqlite::Error::QueryReturnedNoRows => Err(DatastoreError::NoSuchValue),
+                rusqlite::Error::QueryReturnedNoRows => Err(DatastoreError::NoSuchKey),
                 _ => Err(DatastoreError::InternalError(
                               format!("Get value query failed for key {}", key))
                 )
@@ -678,7 +678,7 @@ impl DatastoreInstance {
                 Ok(output)
             }
             Err(err) => match err {
-                rusqlite::Error::QueryReturnedNoRows => Err(DatastoreError::NoSuchValue),
+                rusqlite::Error::QueryReturnedNoRows => Err(DatastoreError::NoSuchKey),
                 _ => Err(DatastoreError::InternalError(format!(
                     "Failed to get key_value rows starting with pattern {}",
                     pattern

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -639,7 +639,7 @@ impl DatastoreInstance {
             Ok(KeyValue {
                 key: row.get(0)?, 
                 value: row.get(1)?,
-                timestamp: DateTime::from_utc(NaiveDateTime::from_timestamp(row.get(2)?, 0), Utc)
+                timestamp: Some(DateTime::from_utc(NaiveDateTime::from_timestamp(row.get(2)?, 0), Utc))
             }
             )}) 
         {

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -127,8 +127,7 @@ fn _migrate_v3_to_v4(conn: &Connection) {
     conn.execute("CREATE TABLE key_value (
         key TEXT PRIMARY KEY,
         value TEXT
-    ), '{}';", &[] as &[&dyn ToSql])
-        .expect("Failed to upgrade db and add key-value storage table");
+    );", rusqlite::NO_PARAMS).expect("Failed to upgrade db and add key-value storage table");
 
     conn.pragma_update(None, "user_version", &4).expect("Failed to update database version!");
 }
@@ -598,7 +597,7 @@ impl DatastoreInstance {
     }
 
     pub fn create_value(&self, conn: &Connection, key: &str, data: &str)
-        -> Result<&str, DatastoreError> {
+        -> Result<(), DatastoreError> {
 
         let mut stmt = match conn.prepare("
                 INSERT OR REPLACE INTO key_value(key, data)
@@ -609,33 +608,20 @@ impl DatastoreInstance {
             ))
         };
 
-        let res = stmt.execute(&[key as &str, data as &str]);
-        return match res {
-            Ok(_) => Ok(data),
-            Err(err) => {
-                Err(DatastoreError::InternalError(
-                    format!("Failed to insert key-value pair: {:?}, {}", key, err)
-                ))
-            }
-        }
+        stmt.execute(&[key as &str, data as &str]).expect(
+                &format!("Failed to insert key-value pair: {}", key)
+        );
+        Ok(())
     }
 
     pub fn delete_value(&self, conn: &Connection, key: &str) -> Result<(), DatastoreError>{
-        return match conn.execute("DELETE FROM key_value WHERE key = ?1", &[key]) {
-            Ok(_) => {
-                Ok(())
-            },
-            Err(err) => match err {
-                rusqlite::Error::SqliteFailure { 0: sqlerr, 1: _ } =>
-                    Err(DatastoreError::InternalError(err.to_string())),
-
-                err => Err(DatastoreError::InternalError(err.to_string()))
-            }
-        }
+        conn.execute("DELETE FROM key_value WHERE key = ?1", &[key])
+            .expect("Error deleting value from database");
+        Ok(())
     }
 
 
-    pub fn get_value(&self, conn: &Connection, key: &str) -> Result<&str, DatastoreError>{
+    pub fn get_value(&self, conn: &Connection, key: &str) -> Result<String, DatastoreError>{
         let mut stmt = match conn.prepare("
                 SELECT * FROM key_value WHERE KEY = ?1") {
             Ok(stmt) => stmt,
@@ -644,14 +630,10 @@ impl DatastoreInstance {
             ))
         };
 
-        let res = stmt.execute(&[key as &str]);
-        return match res {
-            Ok(_) => Ok(data),
-            Err(err) => {
-                Err(DatastoreError::InternalError(
-                    format!("Failed to get value with key: {:?}, {}", key, err)
-                ))
-            }
-        }
+        let result: String= stmt.query_row(&[key as &str], |row|{
+            row.get(0)
+        }).expect(&"Invalid type value received from db query.");
+
+        Ok(result)
     }
 }

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -599,7 +599,7 @@ impl DatastoreInstance {
         return Ok(count);
     }
 
-    pub fn insert_value(&self, conn: &Connection, key: &str, data: &str)
+    pub fn insert_key_value(&self, conn: &Connection, key: &str, data: &str)
         -> Result<(), DatastoreError> {
 
         let mut stmt = match conn.prepare("
@@ -616,13 +616,13 @@ impl DatastoreInstance {
         return Ok(())
     }
 
-    pub fn delete_value(&self, conn: &Connection, key: &str) -> Result<(), DatastoreError>{
+    pub fn delete_key_value(&self, conn: &Connection, key: &str) -> Result<(), DatastoreError>{
         conn.execute("DELETE FROM key_value WHERE key = ?1", &[key])
             .expect("Error deleting value from database");
         return Ok(())
     }
 
-    pub fn get_value(&self, conn: &Connection, key: &str) -> Result<String, DatastoreError>{
+    pub fn get_key_value(&self, conn: &Connection, key: &str) -> Result<String, DatastoreError>{
         let mut stmt = match conn.prepare("
                 SELECT * FROM key_value WHERE KEY = ?1") {
             Ok(stmt) => stmt,
@@ -644,7 +644,7 @@ impl DatastoreInstance {
         }
     }
 
-    pub fn get_values_starting(&self, conn: &Connection, pattern: &str)
+    pub fn get_keys_starting(&self, conn: &Connection, pattern: &str)
         -> Result<HashMap<String, String>, DatastoreError>
     {
         let mut stmt = match conn.prepare("SELECT * FROM key_value WHERE key LIKE '.%' ") {

--- a/aw-datastore/src/lib.rs
+++ b/aw-datastore/src/lib.rs
@@ -31,7 +31,7 @@ pub enum DatastoreMethod {
 pub enum DatastoreError {
     NoSuchBucket,
     BucketAlreadyExists,
-    NoSuchValue,
+    NoSuchKey,
     MpscError,
     InternalError(String),
     // Errors specific to when migrate is disabled

--- a/aw-datastore/src/lib.rs
+++ b/aw-datastore/src/lib.rs
@@ -31,6 +31,7 @@ pub enum DatastoreMethod {
 pub enum DatastoreError {
     NoSuchBucket,
     BucketAlreadyExists,
+    NoSuchValue,
     MpscError,
     InternalError(String),
     // Errors specific to when migrate is disabled

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -417,11 +417,11 @@ impl Datastore {
         }
     }
 
-    pub fn get_values_starting(&self, key: &str) -> Result<HashMap<String, String>, DatastoreError> {
-        let cmd = Commands::GetValuesStarting(key.to_string());
+    pub fn get_values_starting(&self, pattern: &str) -> Result<HashMap<String, String>, DatastoreError> {
+        let cmd = Commands::GetValuesStarting(pattern.to_string());
         let receiver = self.requester.request(cmd).unwrap();
         
-        match receiver.collect().unwrap() {
+        match receiver.collect().expect("This should unwrap") {
             Ok(r) => match r {
                 Responses::KeyValueMap(value) => return Ok(value),
                 _ => panic!("Invalid response")

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -420,7 +420,7 @@ impl Datastore {
     pub fn get_values_starting(&self, key: &str) -> Result<HashMap<String, String>, DatastoreError> {
         let cmd = Commands::GetValuesStarting(key.to_string());
         let receiver = self.requester.request(cmd).unwrap();
-
+        
         match receiver.collect().unwrap() {
             Ok(r) => match r {
                 Responses::KeyValueMap(value) => return Ok(value),

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -49,7 +49,7 @@ pub enum Responses {
     EventList(Vec<Event>),
     Count(i64),
     String(String),
-    KeyValueMap(HashMap<String, String>),
+    StringVec(Vec<String>),
 }
 
 #[derive(Debug,Clone)]
@@ -224,7 +224,7 @@ impl DatastoreWorker {
                     },
                     Commands::GetKeysStarting(pattern) => {
                         match ds.get_keys_starting(&transaction, &pattern) {
-                            Ok(result) => Ok(Responses::KeyValueMap(result)),
+                            Ok(result) => Ok(Responses::StringVec(result)),
                             Err(e) => Err(e)
                         }
                         
@@ -419,13 +419,13 @@ impl Datastore {
         }
     }
 
-    pub fn get_keys_starting(&self, pattern: &str) -> Result<HashMap<String, String>, DatastoreError> {
+    pub fn get_keys_starting(&self, pattern: &str) -> Result<Vec<String>, DatastoreError> {
         let cmd = Commands::GetKeysStarting(pattern.to_string());
         let receiver = self.requester.request(cmd).unwrap();
         
         match receiver.collect().unwrap() {
             Ok(r) => match r {
-                Responses::KeyValueMap(value) => return Ok(value),
+                Responses::StringVec(value) => return Ok(value),
                 _ => panic!("Invalid response")
             },
             Err(e) => Err(e)

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -421,7 +421,7 @@ impl Datastore {
         let cmd = Commands::GetValuesStarting(pattern.to_string());
         let receiver = self.requester.request(cmd).unwrap();
         
-        match receiver.collect().expect("This should unwrap") {
+        match receiver.collect().unwrap() {
             Ok(r) => match r {
                 Responses::KeyValueMap(value) => return Ok(value),
                 _ => panic!("Invalid response")
@@ -429,5 +429,4 @@ impl Datastore {
             Err(e) => Err(e)
         }
     }
-
 }

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -63,7 +63,7 @@ pub enum Commands {
     GetEventCount(String, Option<DateTime<Utc>>, Option<DateTime<Utc>>),
     DeleteEventsById(String, Vec<i64>),
     ForceCommit(),
-    CreateValue(String, String),
+    InsertValue(String, String),
     GetValue(String),
     DeleteValue(String),
 }
@@ -208,8 +208,8 @@ impl DatastoreWorker {
                         commit = true;
                         Ok(Responses::Empty())
                     },
-                    Commands::CreateValue(key, data) => {
-                        match ds.create_value(&transaction, &key, &data) {
+                    Commands::InsertValue(key, data) => {
+                        match ds.insert_value(&transaction, &key, &data) {
                             Ok(()) => Ok(Responses::Empty()),
                             Err(e) => Err(e)
                         }
@@ -382,8 +382,8 @@ impl Datastore {
         }
     }
 
-    pub fn create_value(&self, key: &str, data: &str) -> Result<(), DatastoreError> {
-        let cmd = Commands::CreateValue(key.to_string(), data.to_string());
+    pub fn insert_value(&self, key: &str, data: &str) -> Result<(), DatastoreError> {
+        let cmd = Commands::InsertValue(key.to_string(), data.to_string());
         let receiver = self.requester.request(cmd).unwrap();
 
         _unwrap_response(receiver)

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -11,6 +11,7 @@ use rusqlite::TransactionBehavior;
 
 use aw_models::Bucket;
 use aw_models::Event;
+use aw_models::KeyValue;
 
 use crate::DatastoreError;
 use crate::DatastoreMethod;
@@ -48,7 +49,7 @@ pub enum Responses {
     Event(Event),
     EventList(Vec<Event>),
     Count(i64),
-    String(String),
+    KeyValue(KeyValue),
     StringVec(Vec<String>),
 }
 
@@ -218,7 +219,7 @@ impl DatastoreWorker {
                     },
                     Commands::GetKeyValue(key) => {
                         match ds.get_key_value(&transaction, &key) {
-                            Ok(result) => Ok(Responses::String(result)),
+                            Ok(result) => Ok(Responses::KeyValue(result)),
                             Err(e) => Err(e)
                         }
                     },
@@ -406,13 +407,13 @@ impl Datastore {
         _unwrap_response(receiver)
     }
 
-    pub fn get_key_value(&self, key: &str) -> Result<String, DatastoreError> {
+    pub fn get_key_value(&self, key: &str) -> Result<KeyValue, DatastoreError> {
         let cmd = Commands::GetKeyValue(key.to_string());
         let receiver = self.requester.request(cmd).unwrap();
 
         match receiver.collect().unwrap() {
             Ok(r) => match r {
-                Responses::String(value) => return Ok(value),
+                Responses::KeyValue(value) => return Ok(value),
                 _ => panic!("Invalid response")
             },
             Err(e) => Err(e)

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -424,8 +424,11 @@ impl Datastore {
         let receiver = self.requester.request(cmd).unwrap();
         
         match receiver.collect().unwrap() {
+
             Ok(r) => match r {
-                Responses::StringVec(value) => return Ok(value),
+                Responses::StringVec(value) => { 
+                    return Ok(value)
+                },
                 _ => panic!("Invalid response")
             },
             Err(e) => Err(e)

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -64,10 +64,10 @@ pub enum Commands {
     GetEventCount(String, Option<DateTime<Utc>>, Option<DateTime<Utc>>),
     DeleteEventsById(String, Vec<i64>),
     ForceCommit(),
-    InsertValue(String, String),
-    GetValue(String),
-    GetValuesStarting(String),
-    DeleteValue(String),
+    InsertKeyValue(String, String),
+    GetKeyValue(String),
+    GetKeysStarting(String),
+    DeleteKeyValue(String),
 }
 
 struct DatastoreWorker {
@@ -210,26 +210,28 @@ impl DatastoreWorker {
                         commit = true;
                         Ok(Responses::Empty())
                     },
-                    Commands::InsertValue(key, data) => {
-                        match ds.insert_value(&transaction, &key, &data) {
+                    Commands::InsertKeyValue(key, data) => {
+                        match ds.insert_key_value(&transaction, &key, &data) {
                             Ok(()) => Ok(Responses::Empty()),
                             Err(e) => Err(e)
                         }
                     },
-                    Commands::GetValue(key) => {
-                        match ds.get_value(&transaction, &key) {
+                    Commands::GetKeyValue(key) => {
+                        match ds.get_key_value(&transaction, &key) {
                             Ok(result) => Ok(Responses::String(result)),
                             Err(e) => Err(e)
                         }
                     },
-                    Commands::GetValuesStarting(pattern) => {
-                        match ds.get_values_starting(&transaction, &pattern) {
+                    Commands::GetKeysStarting(pattern) => {
+                        match ds.get_keys_starting(&transaction, &pattern) {
                             Ok(result) => Ok(Responses::KeyValueMap(result)),
                             Err(e) => Err(e)
                         }
+                        
+                        
                     },
-                    Commands::DeleteValue(key) => {
-                        match ds.delete_value(&transaction, &key) {
+                    Commands::DeleteKeyValue(key) => {
+                        match ds.delete_key_value(&transaction, &key) {
                             Ok(()) => Ok(Responses::Empty()),
                             Err(e) => Err(e)
                         }
@@ -390,22 +392,22 @@ impl Datastore {
         }
     }
 
-    pub fn insert_value(&self, key: &str, data: &str) -> Result<(), DatastoreError> {
-        let cmd = Commands::InsertValue(key.to_string(), data.to_string());
+    pub fn insert_key_value(&self, key: &str, data: &str) -> Result<(), DatastoreError> {
+        let cmd = Commands::InsertKeyValue(key.to_string(), data.to_string());
         let receiver = self.requester.request(cmd).unwrap();
 
         _unwrap_response(receiver)
     }
 
-    pub fn delete_value(&self, key: &str) -> Result<(), DatastoreError>{
-        let cmd = Commands::DeleteValue(key.to_string());
+    pub fn delete_key_value(&self, key: &str) -> Result<(), DatastoreError>{
+        let cmd = Commands::DeleteKeyValue(key.to_string());
         let receiver = self.requester.request(cmd).unwrap();
 
         _unwrap_response(receiver)
     }
 
-    pub fn get_value(&self, key: &str) -> Result<String, DatastoreError> {
-        let cmd = Commands::GetValue(key.to_string());
+    pub fn get_key_value(&self, key: &str) -> Result<String, DatastoreError> {
+        let cmd = Commands::GetKeyValue(key.to_string());
         let receiver = self.requester.request(cmd).unwrap();
 
         match receiver.collect().unwrap() {
@@ -417,8 +419,8 @@ impl Datastore {
         }
     }
 
-    pub fn get_values_starting(&self, pattern: &str) -> Result<HashMap<String, String>, DatastoreError> {
-        let cmd = Commands::GetValuesStarting(pattern.to_string());
+    pub fn get_keys_starting(&self, pattern: &str) -> Result<HashMap<String, String>, DatastoreError> {
+        let cmd = Commands::GetKeysStarting(pattern.to_string());
         let receiver = self.requester.request(cmd).unwrap();
         
         match receiver.collect().unwrap() {

--- a/aw-models/src/key_value.rs
+++ b/aw-models/src/key_value.rs
@@ -1,11 +1,21 @@
+use chrono::{DateTime, Utc};
+
 #[derive(Serialize, Deserialize)]
 pub struct Key {
     pub key: String
 }
 
+// TODO: Invent a better naming scheme than calling the non-timestampy one "KV"
+#[derive(Serialize, Deserialize)]
+pub struct KV {
+    pub key: String,
+    pub value: String
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct KeyValue {
     pub key: String,
-    pub value: String
+    pub value: String,
+    pub timestamp: DateTime<Utc> 
 }
 

--- a/aw-models/src/key_value.rs
+++ b/aw-models/src/key_value.rs
@@ -1,0 +1,6 @@
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct KeyValue {
+    pub key: String,
+    pub value: String
+}
+

--- a/aw-models/src/key_value.rs
+++ b/aw-models/src/key_value.rs
@@ -5,23 +5,16 @@ pub struct Key {
     pub key: String
 }
 
-// TODO: Invent a better naming scheme than calling the non-timestampy one "KV"
-#[derive(Serialize, Deserialize, Debug)]
-pub struct KV {
-    pub key: String,
-    pub value: String
-}
-
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct KeyValue {
     pub key: String,
     pub value: String,
-    pub timestamp: DateTime<Utc> 
+    pub timestamp: Option<DateTime<Utc>> 
 }
 
 impl KeyValue {
     pub fn new<T: Into<String>>(key: T, value: T, timestamp: DateTime<Utc>) -> KeyValue {
-        KeyValue {key: key.into(), value: value.into(), timestamp: timestamp }
+        KeyValue {key: key.into(), value: value.into(), timestamp: Some(timestamp) }
     }
 }
 

--- a/aw-models/src/key_value.rs
+++ b/aw-models/src/key_value.rs
@@ -6,16 +6,22 @@ pub struct Key {
 }
 
 // TODO: Invent a better naming scheme than calling the non-timestampy one "KV"
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct KV {
     pub key: String,
     pub value: String
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct KeyValue {
     pub key: String,
     pub value: String,
     pub timestamp: DateTime<Utc> 
+}
+
+impl KeyValue {
+    pub fn new<T: Into<String>>(key: T, value: T, timestamp: DateTime<Utc>) -> KeyValue {
+        KeyValue {key: key.into(), value: value.into(), timestamp: timestamp }
+    }
 }
 

--- a/aw-models/src/key_value.rs
+++ b/aw-models/src/key_value.rs
@@ -1,3 +1,8 @@
+#[derive(Serialize, Deserialize)]
+pub struct Key {
+    pub key: String
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct KeyValue {
     pub key: String,

--- a/aw-models/src/lib.rs
+++ b/aw-models/src/lib.rs
@@ -33,3 +33,4 @@ pub use self::event::Event;
 pub use self::timeinterval::TimeInterval;
 pub use self::query::Query;
 pub use self::key_value::KeyValue;
+pub use self::key_value::Key;

--- a/aw-models/src/lib.rs
+++ b/aw-models/src/lib.rs
@@ -24,6 +24,7 @@ mod bucket;
 mod event;
 mod timeinterval;
 mod query;
+mod key_value;
 
 pub use self::bucket::Bucket;
 pub use self::bucket::BucketMetadata;
@@ -31,3 +32,4 @@ pub use self::bucket::BucketsExport;
 pub use self::event::Event;
 pub use self::timeinterval::TimeInterval;
 pub use self::query::Query;
+pub use self::key_value::KeyValue;

--- a/aw-models/src/lib.rs
+++ b/aw-models/src/lib.rs
@@ -33,4 +33,5 @@ pub use self::event::Event;
 pub use self::timeinterval::TimeInterval;
 pub use self::query::Query;
 pub use self::key_value::KeyValue;
+pub use self::key_value::KV;
 pub use self::key_value::Key;

--- a/aw-models/src/lib.rs
+++ b/aw-models/src/lib.rs
@@ -33,5 +33,4 @@ pub use self::event::Event;
 pub use self::timeinterval::TimeInterval;
 pub use self::query::Query;
 pub use self::key_value::KeyValue;
-pub use self::key_value::KV;
 pub use self::key_value::Key;

--- a/aw-server/src/endpoints/key_value.rs
+++ b/aw-server/src/endpoints/key_value.rs
@@ -1,0 +1,51 @@
+use std::collections::HashMap;
+use std::io::Cursor;
+
+use rocket_contrib::json::Json;
+
+use aw_models::Bucket;
+use aw_models::BucketsExport;
+use aw_models::Event;
+
+use rocket::State;
+use rocket::response::status;
+use rocket::response::Response;
+use rocket::http::Header;
+use rocket::http::Status;
+
+use crate::endpoints::ServerState;
+
+use aw_datastore::DatastoreError;
+
+
+#[get("/<key>")]
+pub fn value_get(key: String) -> Result<Json(&str), Status> {
+    let datastore = endpoints_get_lock!(state.datastore);
+    match datastore.get_value(key) {
+        Ok(result) => Ok(Json(result)),
+        Err(e) => match e {
+            _ => {
+                warn!("Unexpected error: {:?}", e);
+                Err(Status::InternalServerError)
+            }
+        }
+    }
+}
+
+#[post("/<key>", data = "<message>")]
+pub fn value_new(key: String, message: Json<String>) -> Result<(), Status>{
+    let data = message.into_inner();
+
+    let datastore = endpoints_get_lock!(state.datastore);
+    
+    let ret = datastore.create_value(key, data);
+    match ret {
+        Ok(_) => Ok(()),
+        Err(e) => match e {
+            DatastoreError::Custom=> Err(Status::Custom(Status::NotModified, ())),
+            _ => {
+                Err(Status::InternalServerError)
+            }
+        }
+    }
+}

--- a/aw-server/src/endpoints/key_value.rs
+++ b/aw-server/src/endpoints/key_value.rs
@@ -14,13 +14,13 @@ pub fn value_new(state: State<ServerState>, key: String, message: Json<String>)
     let data = message.into_inner();
     let datastore: MutexGuard<'_, Datastore> = endpoints_get_lock!(state.datastore);
     let result = datastore.create_value(&key, &data);
-    return result.expect("Value not created")
+    return Ok(result.expect("Value not created"))
 }
 
-#[get("/<key>")]
+#[get("/<key>")] // Is the json in the return type required?
 pub fn value_get(state: State<ServerState>, key: String) -> Result<Json<String>, Status> {
     let datastore = endpoints_get_lock!(state.datastore);
-    return Ok(datastore.get_value(&key).expect("Error getting value {}"))
+    return Ok(Json(datastore.get_value(&key).expect("Error getting value {}")))
 }
 
 #[delete("/<key>")]

--- a/aw-server/src/endpoints/key_value.rs
+++ b/aw-server/src/endpoints/key_value.rs
@@ -23,8 +23,8 @@ pub fn value_new(state: State<ServerState>, key: String, message: Json<String>)
 pub fn value_get(state: State<ServerState>, key: String) -> Result<String, Status> {
     let datastore = endpoints_get_lock!(state.datastore);
     return match datastore.get_value(&key) {
-        Ok(result) => Ok(result + "\n"),
-        Err(DatastoreError::NoSuchValue) => Ok(Status::NoContent.to_string()),
+        Ok(result) => Ok(result),
+        Err(DatastoreError::NoSuchValue) => Ok("No such value".to_string()),
         Err(_) => Err(Status::InternalServerError)
     }
 }

--- a/aw-server/src/endpoints/key_value.rs
+++ b/aw-server/src/endpoints/key_value.rs
@@ -10,6 +10,8 @@ use aw_datastore::{Datastore, DatastoreError};
 pub fn value_new(state: State<ServerState>, key: String, message: Json<String>)
     -> Result<Status, Status> {
 
+    if key.len() >= 128 { return Err(Status::BadRequest) };;
+
     let data = message.into_inner();
     let datastore: MutexGuard<'_, Datastore> = endpoints_get_lock!(state.datastore);
     let result = datastore.insert_value(&key, &data);
@@ -25,6 +27,8 @@ pub fn value_new(state: State<ServerState>, key: String, message: Json<String>)
 
 #[get("/<key>")]
 pub fn value_get(state: State<ServerState>, key: String) -> Result<String, Status> {
+    if key.len() >= 128 { return Err(Status::BadRequest) };;
+
     let datastore = endpoints_get_lock!(state.datastore);
     return match datastore.get_value(&key) {
         Ok(result) => Ok(result),
@@ -38,6 +42,8 @@ pub fn value_get(state: State<ServerState>, key: String) -> Result<String, Statu
 
 #[delete("/<key>")]
 pub fn value_delete(state: State<ServerState>, key: String) -> Result<(), Status> {
+    if key.len() > 128 { return Err(Status::BadRequest) };;
+
     let datastore = endpoints_get_lock!(state.datastore);
     let result = datastore.delete_value(&key);
     return match result {

--- a/aw-server/src/endpoints/key_value.rs
+++ b/aw-server/src/endpoints/key_value.rs
@@ -4,7 +4,7 @@ use rocket::http::Status;
 use rocket::State;
 use crate::endpoints::ServerState;
 
-use aw_datastore::Datastore;
+use aw_datastore::{Datastore, DatastoreError};
 
 #[post("/<key>", data="<message>")]
 pub fn value_new(state: State<ServerState>, key: String, message: Json<String>)
@@ -14,8 +14,8 @@ pub fn value_new(state: State<ServerState>, key: String, message: Json<String>)
     let datastore: MutexGuard<'_, Datastore> = endpoints_get_lock!(state.datastore);
     let result = datastore.create_value(&key, &data);
     return match result {
-        Ok(r) => Ok(Status::Created),
-        Err(err) => Err(Status::InternalServerError)
+        Ok(_) => Ok(Status::Created),
+        Err(_) => Err(Status::InternalServerError)
     }
 }
 
@@ -23,12 +23,8 @@ pub fn value_new(state: State<ServerState>, key: String, message: Json<String>)
 pub fn value_get(state: State<ServerState>, key: String) -> Result<String, Status> {
     let datastore = endpoints_get_lock!(state.datastore);
     return match datastore.get_value(&key) {
-        Ok(result) =>
-            if result == "QueryReturnedNoRows" {
-                Ok(Status::NoContent.to_string())
-            } else {
-                Ok(result)
-            },
+        Ok(result) => Ok(result + "\n"),
+        Err(DatastoreError::NoSuchValue) => Ok(Status::NoContent.to_string()),
         Err(_) => Err(Status::InternalServerError)
     }
 }

--- a/aw-server/src/endpoints/key_value.rs
+++ b/aw-server/src/endpoints/key_value.rs
@@ -1,51 +1,31 @@
-use std::collections::HashMap;
-use std::io::Cursor;
-
+use std::sync::MutexGuard;
 use rocket_contrib::json::Json;
-
-use aw_models::Bucket;
-use aw_models::BucketsExport;
-use aw_models::Event;
-
-use rocket::State;
-use rocket::response::status;
-use rocket::response::Response;
-use rocket::http::Header;
 use rocket::http::Status;
-
+use rocket::State;
 use crate::endpoints::ServerState;
 
+use aw_datastore::Datastore;
 use aw_datastore::DatastoreError;
 
+#[post("/<key>", data="<message>")]
+pub fn value_new(state: State<ServerState>, key: String, message: Json<String>)
+    -> Result<(), Status> {
 
-#[get("/<key>")]
-pub fn value_get(key: String) -> Result<Json(&str), Status> {
-    let datastore = endpoints_get_lock!(state.datastore);
-    match datastore.get_value(key) {
-        Ok(result) => Ok(Json(result)),
-        Err(e) => match e {
-            _ => {
-                warn!("Unexpected error: {:?}", e);
-                Err(Status::InternalServerError)
-            }
-        }
-    }
+    let data = message.into_inner();
+    let datastore: MutexGuard<'_, Datastore> = endpoints_get_lock!(state.datastore);
+    let result = datastore.create_value(&key, &data);
+    return result.expect("Value not created")
 }
 
-#[post("/<key>", data = "<message>")]
-pub fn value_new(key: String, message: Json<String>) -> Result<(), Status>{
-    let data = message.into_inner();
-
+#[get("/<key>")]
+pub fn value_get(state: State<ServerState>, key: String) -> Result<Json<String>, Status> {
     let datastore = endpoints_get_lock!(state.datastore);
-    
-    let ret = datastore.create_value(key, data);
-    match ret {
-        Ok(_) => Ok(()),
-        Err(e) => match e {
-            DatastoreError::Custom=> Err(Status::Custom(Status::NotModified, ())),
-            _ => {
-                Err(Status::InternalServerError)
-            }
-        }
-    }
+    return Ok(datastore.get_value(&key).expect("Error getting value {}"))
+}
+
+#[delete("/<key>")]
+pub fn value_delete(state: State<ServerState>, key: String) -> Result<(), Status> {
+    let datastore = endpoints_get_lock!(state.datastore);
+    datastore.delete_value(&key).expect("Error deleting value {}");
+    return Ok(())
 }

--- a/aw-server/src/endpoints/key_value.rs
+++ b/aw-server/src/endpoints/key_value.rs
@@ -12,10 +12,14 @@ pub fn value_new(state: State<ServerState>, key: String, message: Json<String>)
 
     let data = message.into_inner();
     let datastore: MutexGuard<'_, Datastore> = endpoints_get_lock!(state.datastore);
-    let result = datastore.create_value(&key, &data);
+    let result = datastore.insert_value(&key, &data);
     return match result {
+        // TODO: Different status for replacement / creation (requires some sql adjustment)
         Ok(_) => Ok(Status::Created),
-        Err(_) => Err(Status::InternalServerError)
+        Err(err) => {
+            warn!("Unexpected error when creating value: {:?}", err);
+            Err(Status::InternalServerError)
+        }
     }
 }
 
@@ -25,13 +29,22 @@ pub fn value_get(state: State<ServerState>, key: String) -> Result<String, Statu
     return match datastore.get_value(&key) {
         Ok(result) => Ok(result),
         Err(DatastoreError::NoSuchValue) => Err(Status::NotFound),
-        Err(_) => Err(Status::InternalServerError)
+        Err(err) => {
+            warn!("Unexpected error when getting value: {:?}", err);
+            Err(Status::InternalServerError)
+        }
     }
 }
 
 #[delete("/<key>")]
 pub fn value_delete(state: State<ServerState>, key: String) -> Result<(), Status> {
     let datastore = endpoints_get_lock!(state.datastore);
-    datastore.delete_value(&key).expect("Error deleting value {}");
-    return Ok(())
+    let result = datastore.delete_value(&key);
+    return match result {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            warn!("Unexpected error when deleting value: {:?}", err);
+            Err(Status::InternalServerError)
+        }
+    }
 }

--- a/aw-server/src/endpoints/key_value.rs
+++ b/aw-server/src/endpoints/key_value.rs
@@ -24,7 +24,7 @@ pub fn value_get(state: State<ServerState>, key: String) -> Result<String, Statu
     let datastore = endpoints_get_lock!(state.datastore);
     return match datastore.get_value(&key) {
         Ok(result) => Ok(result),
-        Err(DatastoreError::NoSuchValue) => Ok("No such value".to_string()),
+        Err(DatastoreError::NoSuchValue) => Err(Status::NotFound),
         Err(_) => Err(Status::InternalServerError)
     }
 }

--- a/aw-server/src/endpoints/mod.rs
+++ b/aw-server/src/endpoints/mod.rs
@@ -30,7 +30,7 @@ mod query;
 mod import;
 mod cors;
 mod export;
-mod key_value;
+mod settings;
 
 use aw_datastore::Datastore;
 
@@ -152,8 +152,8 @@ pub fn build_rocket(server_state: ServerState, config: &AWConfig) -> rocket::Roc
         .mount("/api/0/export", routes![
                export::buckets_export
         ])
-        .mount("/api/0/key_value", routes![
-            key_value::value_get, key_value::value_new, key_value::value_delete
+        .mount("/api/0/settings", routes![
+            settings::setting_get, settings::setting_new, settings::setting_delete
         ])
         .attach(cors::cors(&config))
         .register(catchers![not_modified, not_found])

--- a/aw-server/src/endpoints/mod.rs
+++ b/aw-server/src/endpoints/mod.rs
@@ -30,6 +30,7 @@ mod query;
 mod import;
 mod cors;
 mod export;
+mod key_value;
 
 use aw_datastore::Datastore;
 
@@ -149,6 +150,9 @@ pub fn build_rocket(server_state: ServerState, config: &AWConfig) -> rocket::Roc
         ])
         .mount("/api/0/export", routes![
                export::buckets_export
+        ])
+        .mount("/api/0/key_value", routes![
+            key_value::value_get, key_value::value_new
         ])
         .attach(cors::cors(&config))
         .register(catchers![not_modified, not_found])

--- a/aw-server/src/endpoints/mod.rs
+++ b/aw-server/src/endpoints/mod.rs
@@ -153,7 +153,7 @@ pub fn build_rocket(server_state: ServerState, config: &AWConfig) -> rocket::Roc
                export::buckets_export
         ])
         .mount("/api/0/settings", routes![
-            settings::setting_get, settings::settings_list_get, settings::setting_new, settings::setting_delete
+            settings::setting_get, settings::settings_list_get, settings::setting_set, settings::setting_delete
         ])
         .attach(cors::cors(&config))
         .register(catchers![not_modified, not_found])

--- a/aw-server/src/endpoints/mod.rs
+++ b/aw-server/src/endpoints/mod.rs
@@ -153,7 +153,7 @@ pub fn build_rocket(server_state: ServerState, config: &AWConfig) -> rocket::Roc
                export::buckets_export
         ])
         .mount("/api/0/settings", routes![
-            settings::setting_get, settings::setting_new, settings::setting_delete
+            settings::setting_get, settings::settings_list_get, settings::setting_new, settings::setting_delete
         ])
         .attach(cors::cors(&config))
         .register(catchers![not_modified, not_found])

--- a/aw-server/src/endpoints/mod.rs
+++ b/aw-server/src/endpoints/mod.rs
@@ -93,6 +93,7 @@ fn server_info() -> JsonValue {
     {
         testing = true;
     }
+    //TODO: Should this be commented?
     #[cfg(not(debug_assertions))]
     {
         testing = false;
@@ -152,7 +153,7 @@ pub fn build_rocket(server_state: ServerState, config: &AWConfig) -> rocket::Roc
                export::buckets_export
         ])
         .mount("/api/0/key_value", routes![
-            key_value::value_get, key_value::value_new
+            key_value::value_get, key_value::value_new, key_value::value_delete
         ])
         .attach(cors::cors(&config))
         .register(catchers![not_modified, not_found])

--- a/aw-server/src/endpoints/settings.rs
+++ b/aw-server/src/endpoints/settings.rs
@@ -25,7 +25,6 @@ pub fn setting_set(state: State<ServerState>, message: Json<KeyValue>) -> Result
     let datastore: MutexGuard<'_, Datastore> = endpoints_get_lock!(state.datastore);
     let result = datastore.insert_key_value(&setting_key, &data.value);
     return match result {
-        // TODO: Different status for replacement / creation (requires some sql adjustment)
         Ok(_) => Ok(Status::Created),
         Err(err) => {
             warn!("Unexpected error when creating setting: {:?}", err);

--- a/aw-server/src/endpoints/settings.rs
+++ b/aw-server/src/endpoints/settings.rs
@@ -2,7 +2,6 @@ use crate::endpoints::ServerState;
 use rocket::http::Status;
 use rocket::State;
 use rocket_contrib::json::{Json, JsonValue};
-use std::collections::HashMap;
 use std::sync::MutexGuard;
 
 use aw_datastore::{Datastore, DatastoreError};

--- a/aw-server/src/endpoints/settings.rs
+++ b/aw-server/src/endpoints/settings.rs
@@ -7,7 +7,7 @@ use crate::endpoints::ServerState;
 use aw_datastore::{Datastore, DatastoreError};
 
 #[post("/<key>", data="<message>")]
-pub fn value_new(state: State<ServerState>, key: String, message: Json<String>)
+pub fn setting_new(state: State<ServerState>, key: String, message: Json<String>)
     -> Result<Status, Status> {
 
     if key.len() >= 128 { return Err(Status::BadRequest) };;
@@ -26,7 +26,7 @@ pub fn value_new(state: State<ServerState>, key: String, message: Json<String>)
 }
 
 #[get("/<key>")]
-pub fn value_get(state: State<ServerState>, key: String) -> Result<String, Status> {
+pub fn setting_get(state: State<ServerState>, key: String) -> Result<String, Status> {
     if key.len() >= 128 { return Err(Status::BadRequest) };;
 
     let datastore = endpoints_get_lock!(state.datastore);
@@ -41,7 +41,7 @@ pub fn value_get(state: State<ServerState>, key: String) -> Result<String, Statu
 }
 
 #[delete("/<key>")]
-pub fn value_delete(state: State<ServerState>, key: String) -> Result<(), Status> {
+pub fn setting_delete(state: State<ServerState>, key: String) -> Result<(), Status> {
     if key.len() > 128 { return Err(Status::BadRequest) };;
 
     let datastore = endpoints_get_lock!(state.datastore);

--- a/aw-server/src/endpoints/settings.rs
+++ b/aw-server/src/endpoints/settings.rs
@@ -2,11 +2,10 @@ use crate::endpoints::ServerState;
 use rocket::http::Status;
 use rocket::State;
 use rocket_contrib::json::Json;
-use std::collections::HashMap;
 use std::sync::MutexGuard;
 
 use aw_datastore::{Datastore, DatastoreError};
-use aw_models::KeyValue;
+use aw_models::{Key, KeyValue};
 
 fn parse_key(key: String) -> Result<String, Status> {
     let namespace: String = "settings.".to_string();
@@ -36,7 +35,7 @@ pub fn setting_set(state: State<ServerState>, message: Json<KeyValue>) -> Result
 }
 
 #[get("/")]
-pub fn settings_list_get(state: State<ServerState>) -> Result<Json<HashMap<&str, String>>, Status> {
+pub fn settings_list_get(state: State<ServerState>) -> Result<Json<Vec<Key>>, Status> {
     let datastore = endpoints_get_lock!(state.datastore);
     let queryresults = match datastore.get_keys_starting("settings.%") {
         Ok(result) => Ok(result),
@@ -47,9 +46,9 @@ pub fn settings_list_get(state: State<ServerState>) -> Result<Json<HashMap<&str,
         }
     };
 
-    let mut output = HashMap::<&str, String>::new();
+    let mut output = Vec::<Key>::new();
     for i in queryresults? {
-        output.insert("key", i);
+        output.push(Key { key: i });
     }
     return Ok(Json(output));
 }

--- a/aw-server/src/endpoints/settings.rs
+++ b/aw-server/src/endpoints/settings.rs
@@ -5,7 +5,7 @@ use rocket_contrib::json::Json;
 use std::sync::MutexGuard;
 
 use aw_datastore::{Datastore, DatastoreError};
-use aw_models::{Key, KV, KeyValue};
+use aw_models::{Key, KeyValue};
 
 fn parse_key(key: String) -> Result<String, Status> {
     let namespace: String = "settings.".to_string();
@@ -17,7 +17,7 @@ fn parse_key(key: String) -> Result<String, Status> {
 }
 
 #[post("/", data = "<message>")]
-pub fn setting_set(state: State<ServerState>, message: Json<KV>) -> Result<Status, Status> {
+pub fn setting_set(state: State<ServerState>, message: Json<KeyValue>) -> Result<Status, Status> {
     let data = message.into_inner();
 
     let setting_key = parse_key(data.key)?;

--- a/aw-server/src/endpoints/settings.rs
+++ b/aw-server/src/endpoints/settings.rs
@@ -5,7 +5,7 @@ use rocket_contrib::json::Json;
 use std::sync::MutexGuard;
 
 use aw_datastore::{Datastore, DatastoreError};
-use aw_models::{Key, KeyValue};
+use aw_models::{Key, KV, KeyValue};
 
 fn parse_key(key: String) -> Result<String, Status> {
     let namespace: String = "settings.".to_string();
@@ -17,7 +17,7 @@ fn parse_key(key: String) -> Result<String, Status> {
 }
 
 #[post("/", data = "<message>")]
-pub fn setting_set(state: State<ServerState>, message: Json<KeyValue>) -> Result<Status, Status> {
+pub fn setting_set(state: State<ServerState>, message: Json<KV>) -> Result<Status, Status> {
     let data = message.into_inner();
 
     let setting_key = parse_key(data.key)?;
@@ -59,10 +59,7 @@ pub fn setting_get(state: State<ServerState>, key: String) -> Result<Json<KeyVal
 
     let datastore = endpoints_get_lock!(state.datastore);
     return match datastore.get_key_value(&setting_key) {
-        Ok(result) => Ok(Json(KeyValue {
-            key: setting_key,
-            value: result,
-        })),
+        Ok(result) => Ok(Json(result)),
         Err(DatastoreError::NoSuchKey) => Err(Status::NotFound),
         Err(err) => {
             warn!("Unexpected error when getting setting: {:?}", err);

--- a/aw-server/src/endpoints/settings.rs
+++ b/aw-server/src/endpoints/settings.rs
@@ -26,7 +26,7 @@ pub fn setting_set(
     let setting_key = parse_key(data.key)?;
 
     let datastore: MutexGuard<'_, Datastore> = endpoints_get_lock!(state.datastore);
-    let result = datastore.insert_value(&setting_key, &data.value);
+    let result = datastore.insert_key_value(&setting_key, &data.value);
     return match result {
         // TODO: Different status for replacement / creation (requires some sql adjustment)
         Ok(_) => Ok(Status::Created),
@@ -42,7 +42,7 @@ pub fn settings_list_get(
     state: State<ServerState>,
 ) -> Result<JsonValue, Status> {
     let datastore = endpoints_get_lock!(state.datastore);
-    return match datastore.get_values_starting("settings.") {
+    return match datastore.get_keys_starting("settings.") {
         Ok(result) => Ok(json!(result)),
         Err(DatastoreError::NoSuchValue) => Err(Status::NotFound),
         Err(err) => {
@@ -57,7 +57,7 @@ pub fn setting_get(state: State<ServerState>, key: String) -> Result<Json<KeyVal
     let setting_key = parse_key(key)?;
 
     let datastore = endpoints_get_lock!(state.datastore);
-    return match datastore.get_value(&setting_key) {
+    return match datastore.get_key_value(&setting_key) {
         Ok(result) => Ok(Json(KeyValue{ key: setting_key, value: result })),
         Err(DatastoreError::NoSuchValue) => Err(Status::NotFound),
         Err(err) => {
@@ -72,7 +72,7 @@ pub fn setting_delete(state: State<ServerState>, key: String) -> Result<(), Stat
     let setting_key = parse_key(key)?;
 
     let datastore = endpoints_get_lock!(state.datastore);
-    let result = datastore.delete_value(&setting_key);
+    let result = datastore.delete_key_value(&setting_key);
     return match result {
         Ok(_) => Ok(()),
         Err(err) => {

--- a/aw-server/src/endpoints/settings.rs
+++ b/aw-server/src/endpoints/settings.rs
@@ -41,16 +41,23 @@ pub fn setting_set(
 #[get("/")]
 pub fn settings_list_get(
     state: State<ServerState>,
-) -> Result<Json<HashMap<String, String>>, Status> {
+) -> Result<Json<HashMap<&str, String>>, Status> {
     let datastore = endpoints_get_lock!(state.datastore);
-    return match datastore.get_keys_starting("settings.") {
-        Ok(result) => Ok(Json(result)),
+    let queryresults = match datastore.get_keys_starting("settings.") {
+        Ok(result) => Ok(result),
         Err(DatastoreError::NoSuchKey) => Err(Status::NotFound),
         Err(err) => {
             warn!("Unexpected error when getting setting: {:?}", err);
             Err(Status::InternalServerError)
         }
     };
+
+    let mut output = HashMap::<&str, String>::new();
+    for i in queryresults? {
+        output.insert("key", i);
+    }
+    return Ok(Json(output));
+
 }
 
 #[get("/<key>")]

--- a/aw-server/src/endpoints/settings.rs
+++ b/aw-server/src/endpoints/settings.rs
@@ -1,8 +1,9 @@
 use crate::endpoints::ServerState;
 use rocket::http::Status;
 use rocket::State;
-use rocket_contrib::json::{Json, JsonValue};
+use rocket_contrib::json::Json;
 use std::sync::MutexGuard;
+use std::collections::HashMap;
 
 use aw_datastore::{Datastore, DatastoreError};
 use aw_models::KeyValue;
@@ -40,11 +41,11 @@ pub fn setting_set(
 #[get("/")]
 pub fn settings_list_get(
     state: State<ServerState>,
-) -> Result<JsonValue, Status> {
+) -> Result<Json<HashMap<String, String>>, Status> {
     let datastore = endpoints_get_lock!(state.datastore);
     return match datastore.get_keys_starting("settings.") {
-        Ok(result) => Ok(json!(result)),
-        Err(DatastoreError::NoSuchValue) => Err(Status::NotFound),
+        Ok(result) => Ok(Json(result)),
+        Err(DatastoreError::NoSuchKey) => Err(Status::NotFound),
         Err(err) => {
             warn!("Unexpected error when getting setting: {:?}", err);
             Err(Status::InternalServerError)
@@ -59,7 +60,7 @@ pub fn setting_get(state: State<ServerState>, key: String) -> Result<Json<KeyVal
     let datastore = endpoints_get_lock!(state.datastore);
     return match datastore.get_key_value(&setting_key) {
         Ok(result) => Ok(Json(KeyValue{ key: setting_key, value: result })),
-        Err(DatastoreError::NoSuchValue) => Err(Status::NotFound),
+        Err(DatastoreError::NoSuchKey) => Err(Status::NotFound),
         Err(err) => {
             warn!("Unexpected error when getting setting: {:?}", err);
             Err(Status::InternalServerError)

--- a/aw-server/src/endpoints/settings.rs
+++ b/aw-server/src/endpoints/settings.rs
@@ -1,14 +1,14 @@
 use crate::endpoints::ServerState;
 use rocket::http::Status;
 use rocket::State;
-use rocket_contrib::json::Json;
+use rocket_contrib::json::{Json, JsonValue};
 use std::collections::HashMap;
 use std::sync::MutexGuard;
 
 use aw_datastore::{Datastore, DatastoreError};
 
 fn parse_key(key: String) -> Result<String, Status> {
-    let mut namespace: String = "settings.".to_string();
+    let namespace: String = "settings.".to_string();
     if key.len() >= 128 {
         return Err(Status::BadRequest);
     } else {
@@ -42,10 +42,10 @@ pub fn setting_new(
 #[get("/")]
 pub fn settings_list_get(
     state: State<ServerState>,
-) -> Result<Json<HashMap<String, String>>, Status> {
+) -> Result<JsonValue, Status> {
     let datastore = endpoints_get_lock!(state.datastore);
     return match datastore.get_values_starting("settings.") {
-        Ok(result) => Ok(Json(result)),
+        Ok(result) => Ok(json!(result)),
         Err(DatastoreError::NoSuchValue) => Err(Status::NotFound),
         Err(err) => {
             warn!("Unexpected error when getting setting: {:?}", err);

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -334,10 +334,11 @@ mod api_tests {
         assert_eq!(res.body_string().unwrap(), r#"{"message":"EmptyQuery","reason":"Internal Server Error (Query Error)","status":500}"#);
     }
 
-    fn create_value_request(client: &Client, key: &str) -> Status {
-        let res = client.post("/api/0/settings/".to_string() + &key.to_string())
+    fn set_setting_request(client: &Client, key: &str) -> Status {
+        use aw_models::KeyValue;
+        let res = client.post("/api/0/settings/")
             .header(ContentType::JSON)
-            .body(r#""test_value""#)
+            .body(KeyValue { key: key, value: "test_value" } )
             .dispatch();
         res.status()
     }
@@ -354,12 +355,12 @@ mod api_tests {
     }
 
     #[test]
-    fn test_creating_value() {
+    fn test_setting_setting() {
         let server = setup_testserver();
         let client = rocket::local::Client::new(server).expect("valid instance");
 
         // Test value creation
-        let response_status = create_value_request(&client, "test_key");
+        let response_status = set_setting_request(&client, "test_key");
         assert_eq!(response_status, rocket::http::Status::Created);
 
     }
@@ -374,15 +375,15 @@ mod api_tests {
         .dispatch();
         assert_eq!(res.status(), rocket::http::Status::NotFound);
     }
-    /// TODO: Add a test for the settings list here
+
     #[test]
     fn settings_list_get() {
         let server = setup_testserver();
         let client = rocket::local::Client::new(server).expect("valid instance");
 
-        let response1_status = create_value_request(&client, "test_key");
+        let response1_status = set_setting_request(&client, "test_key");
         assert_eq!(response1_status, rocket::http::Status::Created);
-        let response2_status = create_value_request(&client, "test_key");
+        let response2_status = set_setting_request(&client, "test_key");
         assert_eq!(response2_status, rocket::http::Status::Created);
 
         let mut res = client.get("/api/0/settings/").dispatch();
@@ -397,7 +398,7 @@ mod api_tests {
         let server = setup_testserver();
         let client = rocket::local::Client::new(server).expect("valid instance");
 
-        let response_status = create_value_request(&client, "test_key");
+        let response_status = set_setting_request(&client, "test_key");
         assert_eq!(response_status, rocket::http::Status::Created);
 
         // Test getting
@@ -411,7 +412,7 @@ mod api_tests {
         let server = setup_testserver();
         let client = rocket::local::Client::new(server).expect("valid instance");
 
-        let response_status = create_value_request(&client, "test_key");
+        let response_status = set_setting_request(&client, "test_key");
         assert_eq!(response_status, rocket::http::Status::Created);
 
         let res = client.post("/api/0/settings/test_key")
@@ -430,7 +431,7 @@ mod api_tests {
         let server = setup_testserver();
         let client = rocket::local::Client::new(server).expect("valid instance");
 
-        let response_status = create_value_request(&client, "test_key");
+        let response_status = set_setting_request(&client, "test_key");
         assert_eq!(response_status, rocket::http::Status::Created);
 
         // Test deleting

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -335,7 +335,7 @@ mod api_tests {
     }
 
     fn create_value_request(client: &Client, key: &str) -> Status {
-        let res = client.post("/api/0/key_value/".to_string() + &key.to_string())
+        let res = client.post("/api/0/settings/".to_string() + &key.to_string())
             .header(ContentType::JSON)
             .body(r#""test_value""#)
             .dispatch();
@@ -348,7 +348,7 @@ mod api_tests {
         let client = rocket::local::Client::new(server).expect("valid instance");
 
         // Test getting not found (getting nonexistent key)
-        let mut res = client.get("/api/0/key_value/thisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongk")
+        let res = client.get("/api/0/settings/thisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongk")
             .dispatch();
         assert_eq!(res.status(), rocket::http::Status::BadRequest);
     }
@@ -370,13 +370,13 @@ mod api_tests {
         let client = rocket::local::Client::new(server).expect("valid instance");
 
         // Test getting not found (getting nonexistent key)
-        let res = client.get("/api/0/key_value/non_existent_key")
+        let res = client.get("/api/0/settings/non_existent_key")
         .dispatch();
         assert_eq!(res.status(), rocket::http::Status::NotFound);
     }
 
     #[test]
-    fn test_getting_value() {
+    fn test_getting_setting() {
         let server = setup_testserver();
         let client = rocket::local::Client::new(server).expect("valid instance");
 
@@ -384,32 +384,32 @@ mod api_tests {
         assert_eq!(response_status, rocket::http::Status::Created);
 
         // Test getting
-        let mut res = client.get("/api/0/key_value/test_key").dispatch();
+        let mut res = client.get("/api/0/settings/test_key").dispatch();
         assert_eq!(res.status(), rocket::http::Status::Ok);
         assert_eq!(res.body_string().unwrap(), r#"test_value"#);
     }
 
     #[test]
-    fn test_updating_value() {
+    fn test_updating_setting() {
         let server = setup_testserver();
         let client = rocket::local::Client::new(server).expect("valid instance");
 
         let response_status = create_value_request(&client, "test_key");
         assert_eq!(response_status, rocket::http::Status::Created);
 
-        let res = client.post("/api/0/key_value/test_key")
+        let res = client.post("/api/0/settings/test_key")
             .header(ContentType::JSON)
             .body(r#""changed_test_value""#)
             .dispatch();
         assert_eq!(res.status(), rocket::http::Status::Created);
 
-        let mut res = client.get("/api/0/key_value/test_key").dispatch();
+        let mut res = client.get("/api/0/settings/test_key").dispatch();
         assert_eq!(res.status(), rocket::http::Status::Ok);
         assert_eq!(res.body_string().unwrap(), r#"changed_test_value"#);
     }
 
     #[test]
-    fn test_deleting_value() {
+    fn test_deleting_setting() {
         let server = setup_testserver();
         let client = rocket::local::Client::new(server).expect("valid instance");
 
@@ -417,10 +417,10 @@ mod api_tests {
         assert_eq!(response_status, rocket::http::Status::Created);
 
         // Test deleting
-        let res = client.delete("/api/0/key_value/test_key").dispatch();
+        let res = client.delete("/api/0/settings/test_key").dispatch();
         assert_eq!(res.status(), rocket::http::Status::Ok);
 
-        let mut res = client.get("/api/0/key_value/test_key").dispatch();
+        let res = client.get("/api/0/settings/test_key").dispatch();
         assert_eq!(res.status(), rocket::http::Status::NotFound);
     }
 }

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -374,6 +374,12 @@ mod api_tests {
         .dispatch();
         assert_eq!(res.status(), rocket::http::Status::NotFound);
     }
+    /// TODO: Add a test for the settings list here
+    #[test]
+    fn settings_list_get() {
+
+        assert!(false)
+    }
 
     #[test]
     fn test_getting_setting() {

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -335,10 +335,10 @@ mod api_tests {
     }
 
     fn set_setting_request(client: &Client, key: &str) -> Status {
-        use aw_models::KeyValue;
+        let body = r#"{ "key": ""#.to_string() + &key + r#"", "value": "test_value" } "#;
         let res = client.post("/api/0/settings/")
             .header(ContentType::JSON)
-            .body(KeyValue { key: key, value: "test_value" } )
+            .body(body)
             .dispatch();
         res.status()
     }
@@ -404,7 +404,7 @@ mod api_tests {
         // Test getting
         let mut res = client.get("/api/0/settings/test_key").dispatch();
         assert_eq!(res.status(), rocket::http::Status::Ok);
-        assert_eq!(res.body_string().unwrap(), r#"test_value"#);
+        assert_eq!(res.body_string().unwrap(), r#"{"key":"settings.test_key","value":"test_value"}"#);
     }
 
     #[test]
@@ -415,15 +415,15 @@ mod api_tests {
         let response_status = set_setting_request(&client, "test_key");
         assert_eq!(response_status, rocket::http::Status::Created);
 
-        let res = client.post("/api/0/settings/test_key")
+        let res = client.post("/api/0/settings/")
             .header(ContentType::JSON)
-            .body(r#""changed_test_value""#)
+            .body(r#" { "key": "test_key", "value": "changed_test_value" }"#)
             .dispatch();
         assert_eq!(res.status(), rocket::http::Status::Created);
 
         let mut res = client.get("/api/0/settings/test_key").dispatch();
         assert_eq!(res.status(), rocket::http::Status::Ok);
-        assert_eq!(res.body_string().unwrap(), r#"changed_test_value"#);
+        assert_eq!(res.body_string().unwrap(), r#"{"key":"settings.test_key","value":"changed_test_value"}"#);
     }
 
     #[test]

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -18,7 +18,7 @@ mod api_tests {
     use aw_server::endpoints;
 
     use aw_models::{Bucket, BucketsExport};
-    use rocket::local::{Client, LocalResponse};
+    use rocket::local::Client;
 
     fn setup_testserver() -> rocket::Rocket {
         let state = endpoints::ServerState {
@@ -361,11 +361,11 @@ mod api_tests {
         // Test getting not found (getting nonexistent key)
         let mut res = client.get("/api/0/key_value/non_existent_key")
         .dispatch();
-        assert_eq!(res.status(), rocket::http::Status::Ok);
-        assert_eq!(res.body_string().unwrap(), r#"No such value"#);
+        assert_eq!(res.status(), rocket::http::Status::NotFound);
+        assert_eq!(res.body_string().unwrap(),
+                   r#"{"reason":"Resource was not found.","status":404}"#
+        );
     }
-
-
 
     #[test]
     fn test_getting_value() {
@@ -413,7 +413,8 @@ mod api_tests {
         assert_eq!(res.status(), rocket::http::Status::Ok);
 
         let mut res = client.get("/api/0/key_value/test_key").dispatch();
-        assert_eq!(res.status(), rocket::http::Status::Ok);
-        assert_eq!(res.body_string().unwrap(), r#"No such value"#);
+        assert_eq!(res.status(), rocket::http::Status::NotFound);
+        assert_eq!(res.body_string().unwrap(),
+                   r#"{"reason":"Resource was not found.","status":404}"#);
     }
 }

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -335,8 +335,8 @@ mod api_tests {
     }
 
     fn set_setting_request(client: &Client, key: &str, value: &str) -> Status {
-        use aw_models::KeyValue;
-        let body = serde_json::to_string(&KeyValue {key: key.to_string(), value: value.to_string()}).unwrap();
+        use aw_models::KV;
+        let body = serde_json::to_string(&KV {key: key.to_string(), value: value.to_string()}).unwrap();
         let res = client.post("/api/0/settings/")
             .header(ContentType::JSON)
             .body(body)
@@ -403,7 +403,7 @@ mod api_tests {
         // Test getting
         let mut res = client.get("/api/0/settings/test_key").dispatch();
         assert_eq!(res.status(), rocket::http::Status::Ok);
-        assert_eq!(res.body_string().unwrap(), r#"{"key":"settings.test_key","value":"test_value"}"#);
+        assert_eq!(res.body_string().unwrap(), r#"{"key":"settings.test_key","value":"test_value","timestamp": }"#);
     }
 
     #[test]
@@ -413,13 +413,17 @@ mod api_tests {
 
         let response_status = set_setting_request(&client, "test_key", "test_value");
         assert_eq!(response_status, rocket::http::Status::Created);
+        
+        let mut res = client.get("/api/0/settings/test_key").dispatch();
+        assert_eq!(res.status(), rocket::http::Status::Ok);
+        assert_eq!(res.body_string().unwrap(), r#"{"key":"settings.test_key","value":"test_value","timestamp":}"#);
     
         let response_2_status = set_setting_request(&client, "test_key", "changed_test_value"); 
         assert_eq!(response_2_status, rocket::http::Status::Created);
 
         let mut res = client.get("/api/0/settings/test_key").dispatch();
         assert_eq!(res.status(), rocket::http::Status::Ok);
-        assert_eq!(res.body_string().unwrap(), r#"{"key":"settings.test_key","value":"changed_test_value"}"#);
+        assert_eq!(res.body_string().unwrap(), r#"{"key":"settings.test_key","value":"changed_test_value","timestamp":}"#);
     }
 
     #[test]

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -377,8 +377,19 @@ mod api_tests {
     /// TODO: Add a test for the settings list here
     #[test]
     fn settings_list_get() {
+        let server = setup_testserver();
+        let client = rocket::local::Client::new(server).expect("valid instance");
 
-        assert!(false)
+        let response1_status = create_value_request(&client, "test_key");
+        assert_eq!(response1_status, rocket::http::Status::Created);
+        let response2_status = create_value_request(&client, "test_key");
+        assert_eq!(response2_status, rocket::http::Status::Created);
+
+        let mut res = client.get("/api/0/settings/").dispatch();
+        
+        assert_eq!(res.status(), rocket::http::Status::Ok);
+        assert_eq!(res.body_string().unwrap(), r#""#);
+        
     }
 
     #[test]

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -343,6 +343,17 @@ mod api_tests {
     }
 
     #[test]
+    fn test_illegally_long_key() {
+        let server = setup_testserver();
+        let client = rocket::local::Client::new(server).expect("valid instance");
+
+        // Test getting not found (getting nonexistent key)
+        let mut res = client.get("/api/0/key_value/thisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongk")
+            .dispatch();
+        assert_eq!(res.status(), rocket::http::Status::BadRequest);
+    }
+
+    #[test]
     fn test_creating_value() {
         let server = setup_testserver();
         let client = rocket::local::Client::new(server).expect("valid instance");
@@ -359,12 +370,9 @@ mod api_tests {
         let client = rocket::local::Client::new(server).expect("valid instance");
 
         // Test getting not found (getting nonexistent key)
-        let mut res = client.get("/api/0/key_value/non_existent_key")
+        let res = client.get("/api/0/key_value/non_existent_key")
         .dispatch();
         assert_eq!(res.status(), rocket::http::Status::NotFound);
-        assert_eq!(res.body_string().unwrap(),
-                   r#"{"reason":"Resource was not found.","status":404}"#
-        );
     }
 
     #[test]
@@ -414,7 +422,5 @@ mod api_tests {
 
         let mut res = client.get("/api/0/key_value/test_key").dispatch();
         assert_eq!(res.status(), rocket::http::Status::NotFound);
-        assert_eq!(res.body_string().unwrap(),
-                   r#"{"reason":"Resource was not found.","status":404}"#);
     }
 }

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -383,14 +383,13 @@ mod api_tests {
 
         let response1_status = set_setting_request(&client, "test_key");
         assert_eq!(response1_status, rocket::http::Status::Created);
-        let response2_status = set_setting_request(&client, "test_key");
+        let response2_status = set_setting_request(&client, "test_key_2");
         assert_eq!(response2_status, rocket::http::Status::Created);
 
         let mut res = client.get("/api/0/settings/").dispatch();
         
         assert_eq!(res.status(), rocket::http::Status::Ok);
-        assert_eq!(res.body_string().unwrap(), r#""#);
-        
+        assert_eq!(res.body_string().unwrap(), r#"{"key":"settings.test_key","key":"settings.test_key_2"}"#);
     }
 
     #[test]

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -337,8 +337,7 @@ mod api_tests {
     }
 
     fn set_setting_request(client: &Client, key: &str, value: &str) -> Status {
-        use aw_models::KV;
-        let body = serde_json::to_string(&KV {key: key.to_string(), value: value.to_string()}).unwrap();
+        let body = serde_json::to_string(&KeyValue {key: key.to_string(), value: value.to_string(), timestamp: None}).unwrap();
         let res = client.post("/api/0/settings/")
             .header(ContentType::JSON)
             .body(body)
@@ -352,10 +351,10 @@ mod api_tests {
         assert_eq!(first.key, second.key);
         assert_eq!(first.value, second.value);
         // Compare with second, not millisecond accuracy
-        assert!(first.timestamp.timestamp() >= before.timestamp(),
-            "{} wasn't after {}", first.timestamp.timestamp(), before.timestamp());
+        assert!(first.timestamp.unwrap().timestamp() >= before.timestamp(),
+            "{} wasn't after {}", first.timestamp.unwrap().timestamp(), before.timestamp());
         assert!(first.timestamp < second.timestamp,
-            "{} wasn't before {}", first.timestamp, second.timestamp);
+            "{} wasn't before {}", first.timestamp.unwrap(), second.timestamp.unwrap());
     }
 
     #[test]

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -389,7 +389,7 @@ mod api_tests {
         let mut res = client.get("/api/0/settings/").dispatch();
         
         assert_eq!(res.status(), rocket::http::Status::Ok);
-        assert_eq!(res.body_string().unwrap(), r#"{"key":"settings.test_key","key":"settings.test_key_2"}"#);
+        assert_eq!(res.body_string().unwrap(), r#"[{"key":"settings.test_key"},{"key":"settings.test_key_2"}]"#); 
     }
 
     #[test]


### PR DESCRIPTION
This PR adds key/value storage functionality. Currently implementing changes based on review feedback.
        
- [x] implement PR feedback
  - [x] rename create_value() to insert_value or something of the sort
  - [x] 204 -> 404 for missing value
  - [x] log errors
  - [x] Add key length limit (maybe 100-128?)
  - [x] rename fns frddom x_value to x_key_value
  - [x] use ? operator in settings.rs
  - [x] nosuchvalue Error -> no such key error
  - [x] Maybe rename functions from insert to set?
  - [x] add response body to _set_setting_request parameters in tests

new features coming into this PR:
- [x] Take json object as input request body `{"key": "sample-key", "value": "sample_Value"}`
- [x] Return json objects (probably `{"key": "settings.sample-key", "value": "sample_Value"}
- [x] Add last_modified column to sql
  - [x] Test timestamps in some sane way
- [x] endpoint for listing all settings key-values
  - [x] test

Open questions:
  - [x] ~~Maybe different status msgs (created vs updated)~~ No.
  - [x] ~~Maybe return timestamp on setting set~~ No.