### PR TITLE
Add git hooks to enforce formatting, clippy and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all aw-server aw-webui build install package test
+.PHONY: all aw-server aw-webui build install package test install-pre-commit pre-commit
 
 all: build
 build: aw-server aw-webui
@@ -11,6 +11,19 @@ aw-server:
 
 aw-webui:
 	make -C ./aw-webui build
+
+install-git-hooks:
+	@printf "make pre-commit\n" > .git/hooks/pre-commit
+	@printf "make pre-push\n" > .git/hooks/pre-push
+	@chmod +x .git/hooks/pre-commit .git/hooks/pre-push
+	@printf "Hooks installed\n"
+
+pre-commit:
+	@cargo fmt -- --check || (printf "Error: Run cargo fmt before committing\n"; exit 1)
+
+pre-push: pre-commit
+	@cargo clippy || (printf "Error: Clippy reported error(s)\n"; exit 1)
+	@cargo test || (printf "Error: Some test(s) failed\n"; exit 1)
 
 test:
 	cargo test

--- a/README.md
+++ b/README.md
@@ -40,3 +40,10 @@ If you want to quick-compile for debugging, run cargo run from the project root
 *NOTE:* this will start aw-server-rust on the testing port 5666 instead of port 5600
 
 ``` cargo run ```
+
+
+### Contributing
+
+Please run `make install-git-hooks` before you start working. This will ensure you only commit properly formatted files, and only push changes that pass tests.
+
+Please use `cargo fmt` and `cargo clippy`; they are quite helpful when developing. Formatter will make the code style consistent, and Clippy will make sure that most common errors and readibility issues will not slip through.

--- a/aw-server/src/config.rs
+++ b/aw-server/src/config.rs
@@ -79,7 +79,9 @@ pub fn get_config() -> AWConfig {
         for line in default_config_str.lines() {
             default_config_str_commented.push_str(&format!("#{}\n", line));
         }
-        wfile.write(&default_config_str_commented.into_bytes()).expect("Failed to write config to file");
+        wfile
+            .write_all(&default_config_str_commented.into_bytes())
+            .expect("Failed to write config to file");
         wfile.sync_all().expect("Unable to sync config file");
     }
 


### PR DESCRIPTION
I also ran rustfmt for the whole codebase, and fixed one clippy error.