### PR TITLE
Add CORS support to config and default config

### DIFF
--- a/aw-server/src/config.rs
+++ b/aw-server/src/config.rs
@@ -12,7 +12,8 @@ pub struct AWConfig {
     pub port: u16,
     #[serde(skip, default = "is_testing")]
     pub testing: bool, // This is not written to the config file (serde(skip))
-                       // TODO: add CORS origins
+    #[serde(default = "default_cors")]
+    pub cors: Vec<String>,
 }
 
 impl Default for AWConfig {
@@ -21,6 +22,7 @@ impl Default for AWConfig {
             address: default_address(),
             port: default_port(),
             testing: is_testing(),
+            cors: default_cors(),
         }
     }
 }
@@ -48,6 +50,14 @@ fn default_port() -> u16 {
     match Environment::active().expect("Failed to get current environment") {
         Environment::Production => 5600,
         Environment::Development => 5666,
+        Environment::Staging => panic!("Staging environment not supported"),
+    }
+}
+
+fn default_cors() -> Vec<String> {
+    match Environment::active().expect("Failed to get current environment") {
+        Environment::Production => Vec::<String>::new(),
+        Environment::Development => Vec::<String>::new(),
         Environment::Staging => panic!("Staging environment not supported"),
     }
 }

--- a/aw-server/src/endpoints/cors.rs
+++ b/aw-server/src/endpoints/cors.rs
@@ -6,9 +6,13 @@ use crate::config::AWConfig;
 
 pub fn cors(config: &AWConfig) -> rocket_cors::Cors {
     let root_url = format!("http://127.0.0.1:{}", config.port).to_string();
-    let mut allowed_exact_origins = vec![root_url];
+    let root_url_localhost = format!("http://localhost:{}", config.port).to_string();
+    let mut allowed_exact_origins = vec![root_url, root_url_localhost];
+    allowed_exact_origins.extend(config.cors.clone());
+
     if config.testing {
         allowed_exact_origins.push("http://127.0.0.1:27180".to_string());
+        allowed_exact_origins.push("http://localhost:27180".to_string());
     }
     let mut allowed_regex_origins = vec![
         "chrome-extension://nglaklhklhcoonedhgnpgddginnjdadi".to_string(),


### PR DESCRIPTION
Adds reading CORS entries from config and writing default CORS entry to config as comment like other config options on first start without config.