### PR TITLE
Add back macro that cargo warns about but is actually used

### DIFF
--- a/aw-models/src/lib.rs
+++ b/aw-models/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate serde;
+#[macro_use]
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
Fixes this https://github.com/ActivityWatch/aw-server-rust/commit/be51837f1ad7ad5c99bb7150dd44bb58b38bf8cf#r37660133 .

I think this case is similar https://www.reddit.com/r/rust/comments/br2bop/unused_import_warning_for_a_macro_thats_actually/ . Should maybe try to find the upstream issue / create one. Probably related to us only using the macro in another macro and some tests, so cargo build doesn't realize it's actually being used.