### PR TITLE
added RELEASE option to Makefile (for faster non-release builds)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,22 @@ build: aw-server aw-webui
 DESTDIR :=
 PREFIX := /usr/local
 
+# Build in release mode by default, unless RELEASE=false
+ifeq ($(RELEASE), false)
+	cargoflag :=
+	targetdir := debug
+else
+	cargoflag := --release
+	targetdir := release
+endif
+
 aw-server:
-	cargo build --release --bin aw-server
+	cargo build $(cargoflag) --bin aw-server
 
 aw-webui:
+ifndef SKIP_WEBUI  # Skip building webui if SKIP_WEBUI is defined
 	make -C ./aw-webui build
+endif
 
 test:
 	cargo test
@@ -20,7 +31,7 @@ package:
 	rm -rf target/package
 	mkdir -p target/package
 	# Copy binary
-	cp target/release/aw-server target/package/aw-server-rust
+	cp target/$(targetdir)/aw-server target/package/aw-server-rust
 	# Copy webui assets
 	cp -rf aw-webui/dist target/package/static
 	# Copy service file
@@ -29,7 +40,7 @@ package:
 install:
 	# Install aw-server executable
 	mkdir -p $(DESTDIR)$(PREFIX)/bin/
-	install -m 755 target/release/aw-server $(DESTDIR)$(PREFIX)/bin/aw-server
+	install -m 755 target/$(targetdir)/aw-server $(DESTDIR)$(PREFIX)/bin/aw-server
 	# Install static web-ui files
 	mkdir -p $(DESTDIR)$(PREFIX)/share/aw-server/static
 	cp -rf aw-webui/dist/* $(DESTDIR)$(PREFIX)/share/aw-server/static


### PR DESCRIPTION
Helps us avoid building aw-server-rust twice in CI (first in release mode, and then in debug mode when tests are run).