### PR TITLE
reduced logging and simplified logging pipeline

### DIFF
--- a/aw-server/src/dirs.rs
+++ b/aw-server/src/dirs.rs
@@ -22,7 +22,7 @@ pub fn get_config_dir() -> Result<PathBuf, ()> {
         let mut dir = appdirs::user_config_dir(Some("activitywatch"), None, false)?;
         dir.push("aw-server-rust");
         fs::create_dir_all(dir.clone()).expect("Unable to create config dir");
-        return Ok(dir);
+        Ok(dir)
     }
 
     #[cfg(target_os = "android")]
@@ -37,7 +37,7 @@ pub fn get_data_dir() -> Result<PathBuf, ()> {
         let mut dir = appdirs::user_data_dir(Some("activitywatch"), None, false)?;
         dir.push("aw-server-rust");
         fs::create_dir_all(dir.clone()).expect("Unable to create data dir");
-        return Ok(dir);
+        Ok(dir)
     }
 
     #[cfg(target_os = "android")]
@@ -52,7 +52,23 @@ pub fn get_cache_dir() -> Result<PathBuf, ()> {
         let mut dir = appdirs::user_cache_dir(Some("activitywatch"), None)?;
         dir.push("aw-server-rust");
         fs::create_dir_all(dir.clone()).expect("Unable to create cache dir");
-        return Ok(dir);
+        Ok(dir)
+    }
+
+    #[cfg(target_os = "android")]
+    {
+        panic!("not implemented on Android");
+    }
+}
+
+pub fn get_log_dir() -> Result<PathBuf, ()> {
+    #[cfg(not(target_os = "android"))]
+    {
+        let mut dir = appdirs::user_cache_dir(Some("activitywatch"), None)?;
+        dir.push("log");
+        dir.push("aw-server-rust");
+        fs::create_dir_all(dir.clone()).expect("Unable to create cache dir");
+        Ok(dir)
     }
 
     #[cfg(target_os = "android")]
@@ -67,7 +83,7 @@ pub fn db_path() -> PathBuf {
     db_path.push("sqlite-testing.db");
     #[cfg(not(debug_assertions))]
     db_path.push("sqlite.db");
-    return db_path;
+    db_path
 }
 
 #[cfg(target_os = "android")]

--- a/aw-server/src/endpoints/mod.rs
+++ b/aw-server/src/endpoints/mod.rs
@@ -9,6 +9,7 @@ use rocket::State;
 use rocket_contrib::json::JsonValue;
 use uuid::Uuid;
 
+use crate::config::is_testing;
 use crate::config::AWConfig;
 use crate::dirs;
 
@@ -88,24 +89,13 @@ fn get_device_id() -> String {
 
 #[get("/")]
 fn server_info() -> JsonValue {
-    let testing: bool;
-    #[cfg(debug_assertions)]
-    {
-        testing = true;
-    }
-    //TODO: Should this be commented?
-    #[cfg(not(debug_assertions))]
-    {
-        testing = false;
-    }
-
     let hostname = gethostname().into_string().unwrap_or("unknown".to_string());
     const VERSION: Option<&'static str> = option_env!("CARGO_PKG_VERSION");
 
     json!({
         "hostname": hostname,
-        "version": format!("aw-server-rust v{}", VERSION.unwrap_or("(unknown)")),
-        "testing": testing,
+        "version": format!("v{} (rust)", VERSION.unwrap_or("(unknown)")),
+        "testing": is_testing(),
         "device_id": get_device_id(),
     })
 }

--- a/aw-server/src/logging.rs
+++ b/aw-server/src/logging.rs
@@ -7,8 +7,7 @@ use crate::dirs;
 
 pub fn setup_logger() -> Result<(), fern::InitError> {
     let mut logfile_path: PathBuf =
-        dirs::get_cache_dir().expect("Unable to get cache dir to store logs in");
-    logfile_path.push("logs");
+        dirs::get_log_dir().expect("Unable to get log dir to store logs in");
     fs::create_dir_all(logfile_path.clone()).expect("Unable to create folder for logs");
     #[cfg(debug_assertions)]
     {
@@ -36,6 +35,7 @@ pub fn setup_logger() -> Result<(), fern::InitError> {
     fern::Dispatch::new()
         // Set some Rocket messages to debug level
         // TODO: Log more if run in development/testing mode
+        .level(log::LevelFilter::Info)
         .level_for("rocket::rocket", log::LevelFilter::Warn)
         .level_for("_", log::LevelFilter::Warn)
         .format(move |out, message, record| {

--- a/aw-server/src/logging.rs
+++ b/aw-server/src/logging.rs
@@ -3,28 +3,22 @@ use std::path::PathBuf;
 
 use fern::colors::{Color, ColoredLevelConfig};
 
+use crate::config::is_production;
 use crate::dirs;
 
 pub fn setup_logger() -> Result<(), fern::InitError> {
     let mut logfile_path: PathBuf =
         dirs::get_log_dir().expect("Unable to get log dir to store logs in");
     fs::create_dir_all(logfile_path.clone()).expect("Unable to create folder for logs");
-    #[cfg(debug_assertions)]
-    {
-        logfile_path.push(
-            chrono::Local::now()
-                .format("aw-server-testing_%Y-%m-%dT%H-%M-%S%z.log")
-                .to_string(),
-        );
-    }
-    #[cfg(not(debug_assertions))]
-    {
-        logfile_path.push(
-            chrono::Local::now()
-                .format("aw-server_%Y-%m-%dT%H-%M-%S%z.log")
-                .to_string(),
-        );
-    }
+    logfile_path.push(
+        chrono::Local::now()
+            .format(if is_production() {
+                "aw-server_%Y-%m-%dT%H-%M-%S%z.log"
+            } else {
+                "aw-server-testing_%Y-%m-%dT%H-%M-%S%z.log"
+            })
+            .to_string(),
+    );
 
     let colors = ColoredLevelConfig::new()
         .debug(Color::White)


### PR DESCRIPTION
I know this will leave ANSI color escape sequences in the logfiles, but dumb to repeat the entire formatting, and if its a big issue there are better ways to do it (but I got tired of looking at fern docs to figure out the way).