### PR TITLE
Use grcov instead of kcov

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,15 +35,37 @@ jobs:
       run: cargo build --workspace --verbose
     - name: Run tests
       run: cargo test --workspace --verbose
-    - name: Run tests with coverage
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-        # Download grcov, unpack the executable to cwd and add cwd to PATH
-        curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
-        export PATH=$PATH:.
-        make coverage-lcov
-        bash <(curl -s https://codecov.io/bash);
 
+  build-coverage:
+    name: Build with coverage
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Rust nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        override: true
+    - name: Cache cargo build
+      uses: actions/cache@v1
+      env:
+        cache-name: cargo-build-target-coverage
+      with:
+        path: target
+        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ env.cache-name }}-
+    - name: Download grcov
+      run: |
+        curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+    - name: Run tests with coverage
+      run: |
+        # Add cwd to path to find grcov
+        export PATH=$PATH:.
+        make coverage-lcov COVERAGE_CACHE=1
+        bash <(curl -s https://codecov.io/bash);
 
   build-android:
     name: Build for Android

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,10 @@ jobs:
     - name: Run tests with coverage
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        sudo apt-get update
-        sudo apt-get install libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev
-        cargo install --force cargo-kcov;
-        cargo kcov --print-install-kcov-sh | sh;
-        cargo kcov --all --verbose;
+        # Download grcov, unpack the executable to cwd and add cwd to PATH
+        curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
+        export PATH=$PATH:.
+        make coverage-lcov
         bash <(curl -s https://codecov.io/bash);
 
 

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,11 @@ COV_RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Cover
 COV_RUSTDOCFLAGS="-Cpanic=abort"
 
 test-coverage:
+ifndef COVERAGE_CACHE
 	# We need to remove build files in case a non-coverage test has been run
 	# before without RUST/CARGO flags needed for coverage
 	rm -rf target/debug
+endif
 	# Build and test
 	CARGO_INCREMENTAL=${COV_CARGO_INCREMENTAL} \
 	RUSTFLAGS=${COV_RUSTFLAGS} \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all aw-server aw-webui build install package test
+.PHONY: all aw-server aw-webui build install package test test-coverage coverage coverage-html coverage-lcov
 
 all: build
 build: aw-server aw-webui
@@ -25,6 +25,29 @@ endif
 
 test:
 	cargo test
+
+
+COV_CARGO_INCREMENTAL=0
+COV_RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+COV_RUSTDOCFLAGS="-Cpanic=abort"
+
+test-coverage:
+	# We need to remove build files in case a non-coverage test has been run
+	# before without RUST/CARGO flags needed for coverage
+	rm -rf target/debug
+	# Build and test
+	CARGO_INCREMENTAL=${COV_CARGO_INCREMENTAL} \
+	RUSTFLAGS=${COV_RUSTFLAGS} \
+	RUSTDOCFLAGS=${COV_RUSTDOCFLAGS} \
+		cargo test
+
+coverage-html: test-coverage
+	grcov ./target/debug/ -s . -t html --llvm --branch --ignore-not-existing -o ./target/debug/$@/
+
+coverage-lcov: test-coverage
+	grcov ./target/debug/ -s . -t lcov --llvm --branch --ignore-not-existing -o ./target/debug/$@.txt
+
+coverage: coverage-html
 
 package:
 	# Clean and prepare target/package folder

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,4 @@
+bucket already exists test
+get_keys_starting no rows test
+event model default duration test
+make a log message in logging.rs test


### PR DESCRIPTION
Wants to solve #117 

TODO:
- [x] Fix codecov.io not being able to read the lcov report
- [x] Install grcov from pre-built instead of building from source via cargo