### PR TITLE
fix: If events merge during flood, choose the longest endtime

### DIFF
--- a/aw-transform/src/chunk.rs
+++ b/aw-transform/src/chunk.rs
@@ -5,7 +5,7 @@ pub fn chunk_events_by_key(events: Vec<Event>, key: &str) -> Vec<Event> {
     for event in events {
         if chunked_events.is_empty() && event.data.get(key).is_some() {
             // TODO: Add sub-chunks
-            chunked_events.push(event.clone());
+            chunked_events.push(event);
         } else {
             let val = match event.data.get(key) {
                 None => continue,
@@ -20,7 +20,7 @@ pub fn chunk_events_by_key(events: Vec<Event>, key: &str) -> Vec<Event> {
             chunked_events.push(last_event);
             if &last_val != val {
                 // TODO: Add sub-chunks
-                chunked_events.push(event.clone());
+                chunked_events.push(event);
             }
         }
     }

--- a/aw-transform/src/filter_keyvals.rs
+++ b/aw-transform/src/filter_keyvals.rs
@@ -9,7 +9,7 @@ pub fn filter_keyvals(mut events: Vec<Event>, key: &str, vals: &[Value]) -> Vec<
         if let Some(v) = event.data.get(key) {
             for val in vals {
                 if val == v {
-                    filtered_events.push(event.clone());
+                    filtered_events.push(event);
                     break;
                 }
             }
@@ -24,7 +24,7 @@ pub fn filter_keyvals_regex(mut events: Vec<Event>, key: &str, regex: &Regex) ->
     for event in events.drain(..) {
         if let Some(v) = event.data.get(key) {
             if regex.is_match(v.as_str().unwrap()) {
-                filtered_events.push(event.clone());
+                filtered_events.push(event);
             }
         }
     }

--- a/aw-transform/src/flood.rs
+++ b/aw-transform/src/flood.rs
@@ -60,7 +60,7 @@ pub fn flood(events: Vec<Event>, pulsetime: chrono::Duration) -> Vec<Event> {
                 gap_prev = Some(gap);
             }
         }
-        new_events.push(e1.clone());
+        new_events.push(e1);
     }
     new_events
 }


### PR DESCRIPTION
Fixes #140 