### PR TITLE
Fix TODOs

### DIFF
--- a/aw-client-rust/tests/test.rs
+++ b/aw-client-rust/tests/test.rs
@@ -44,6 +44,7 @@ mod test {
         let state = ServerState {
             datastore: Mutex::new(aw_datastore::Datastore::new_in_memory(false)),
             asset_path: PathBuf::from("."), // webui won't be used, so it's invalidly set
+            device_id: "test_id".to_string(),
         };
         let mut aw_config = aw_server::config::AWConfig::default();
         aw_config.port = PORT;

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -382,7 +382,7 @@ impl DatastoreInstance {
             Err(err) => match err {
                 rusqlite::Error::SqliteFailure { 0: sqlerr, 1: _ } => match sqlerr.code {
                     rusqlite::ErrorCode::ConstraintViolation => {
-                        Err(DatastoreError::BucketAlreadyExists)
+                        Err(DatastoreError::BucketAlreadyExists(bucket.id.to_string()))
                     }
                     _ => Err(DatastoreError::InternalError(format!(
                         "Failed to execute create_bucket SQL statement: {}",
@@ -417,7 +417,7 @@ impl DatastoreInstance {
             Err(err) => match err {
                 rusqlite::Error::SqliteFailure { 0: sqlerr, 1: _ } => match sqlerr.code {
                     rusqlite::ErrorCode::ConstraintViolation => {
-                        Err(DatastoreError::BucketAlreadyExists)
+                        Err(DatastoreError::BucketAlreadyExists(bucket_id.to_string()))
                     }
                     _ => Err(DatastoreError::InternalError(err.to_string())),
                 },
@@ -430,7 +430,7 @@ impl DatastoreInstance {
         let cached_bucket = self.buckets_cache.get(bucket_id);
         match cached_bucket {
             Some(bucket) => Ok(bucket.clone()),
-            None => Err(DatastoreError::NoSuchBucket),
+            None => Err(DatastoreError::NoSuchBucket(bucket_id.to_string())),
         }
     }
 
@@ -881,7 +881,9 @@ impl DatastoreInstance {
         }) {
             Ok(result) => Ok(result),
             Err(err) => match err {
-                rusqlite::Error::QueryReturnedNoRows => Err(DatastoreError::NoSuchKey),
+                rusqlite::Error::QueryReturnedNoRows => {
+                    Err(DatastoreError::NoSuchKey(key.to_string()))
+                }
                 _ => Err(DatastoreError::InternalError(format!(
                     "Get value query failed for key {}",
                     key
@@ -918,7 +920,9 @@ impl DatastoreInstance {
                 Ok(output)
             }
             Err(err) => match err {
-                rusqlite::Error::QueryReturnedNoRows => Err(DatastoreError::NoSuchKey),
+                rusqlite::Error::QueryReturnedNoRows => {
+                    Err(DatastoreError::NoSuchKey(pattern.to_string()))
+                }
                 _ => Err(DatastoreError::InternalError(format!(
                     "Failed to get key_value rows starting with pattern {}",
                     pattern

--- a/aw-datastore/src/lib.rs
+++ b/aw-datastore/src/lib.rs
@@ -30,9 +30,9 @@ pub enum DatastoreMethod {
 /* TODO: Implement this as a proper error */
 #[derive(Debug, Clone)]
 pub enum DatastoreError {
-    NoSuchBucket,
-    BucketAlreadyExists,
-    NoSuchKey,
+    NoSuchBucket(String),
+    BucketAlreadyExists(String),
+    NoSuchKey(String),
     MpscError,
     InternalError(String),
     // Errors specific to when migrate is disabled

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -39,6 +39,7 @@ impl fmt::Debug for Datastore {
  * TODO:
  * - Allow read requests to go straight through a read-only db connection instead of requesting the
  * worker thread for better performance?
+ * TODO: Add an seperate "Import" request which does an import with an transaction
  */
 
 #[allow(clippy::large_enum_variant)]

--- a/aw-server/src/android/mod.rs
+++ b/aw-server/src/android/mod.rs
@@ -7,6 +7,7 @@ use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::sync::Mutex;
 
+use crate::device_id;
 use crate::dirs;
 
 use android_logger::Config;
@@ -111,6 +112,7 @@ pub mod android {
         let server_state = endpoints::ServerState {
             datastore: Mutex::new(openDatastore()),
             asset_path: PathBuf::from(asset_path),
+            device_id: device_id::get_device_id(),
         };
 
         let mut config = AWConfig::default();

--- a/aw-server/src/device_id.rs
+++ b/aw-server/src/device_id.rs
@@ -1,0 +1,19 @@
+use std::fs;
+
+use uuid::Uuid;
+
+use crate::dirs;
+
+/// Retrieves the device ID, if none exists it generates one (using UUID v4)
+pub fn get_device_id() -> String {
+    // I chose get_data_dir over get_config_dir since the latter isn't yet supported on Android.
+    let mut path = dirs::get_data_dir().unwrap();
+    path.push("device_id");
+    if path.exists() {
+        fs::read_to_string(path).unwrap()
+    } else {
+        let uuid = Uuid::new_v4().to_hyphenated().to_string();
+        fs::write(path, &uuid).unwrap();
+        uuid
+    }
+}

--- a/aw-server/src/endpoints/export.rs
+++ b/aw-server/src/endpoints/export.rs
@@ -8,10 +8,10 @@ use rocket::State;
 
 use aw_models::BucketsExport;
 
-use crate::endpoints::ServerState;
+use crate::endpoints::{HttpErrorJson, ServerState};
 
 #[get("/")]
-pub fn buckets_export(state: State<ServerState>) -> Result<Response, Status> {
+pub fn buckets_export(state: State<ServerState>) -> Result<Response, HttpErrorJson> {
     let datastore = endpoints_get_lock!(state.datastore);
     let mut export = BucketsExport {
         buckets: HashMap::new(),
@@ -19,6 +19,7 @@ pub fn buckets_export(state: State<ServerState>) -> Result<Response, Status> {
     let mut buckets = datastore.get_buckets().unwrap();
     for (bid, mut bucket) in buckets.drain() {
         bucket.events = Some(
+            // TODO: Remove expect
             datastore
                 .get_events(&bid, None, None, None)
                 .expect("Failed to get events for bucket"),

--- a/aw-server/src/endpoints/export.rs
+++ b/aw-server/src/endpoints/export.rs
@@ -16,14 +16,15 @@ pub fn buckets_export(state: State<ServerState>) -> Result<Response, HttpErrorJs
     let mut export = BucketsExport {
         buckets: HashMap::new(),
     };
-    let mut buckets = datastore.get_buckets().unwrap();
+    let mut buckets = match datastore.get_buckets() {
+        Ok(buckets) => buckets,
+        Err(err) => return Err(err.into()),
+    };
     for (bid, mut bucket) in buckets.drain() {
-        bucket.events = Some(
-            // TODO: Remove expect
-            datastore
-                .get_events(&bid, None, None, None)
-                .expect("Failed to get events for bucket"),
-        );
+        bucket.events = Some(match datastore.get_events(&bid, None, None, None) {
+            Ok(events) => events,
+            Err(err) => return Err(err.into()),
+        });
         export.buckets.insert(bid, bucket);
     }
 

--- a/aw-server/src/endpoints/mod.rs
+++ b/aw-server/src/endpoints/mod.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 
 use gethostname::gethostname;
+use rocket::http::Status;
+use rocket::response::status;
 use rocket::response::NamedFile;
 use rocket::State;
 use rocket_contrib::json::JsonValue;
@@ -34,6 +36,28 @@ pub struct ServerState {
     pub datastore: Mutex<Datastore>,
     pub asset_path: PathBuf,
     pub device_id: String,
+}
+
+#[derive(Serialize)]
+struct HttpErrorJson {
+    status: u16,
+    reason: String,
+    message: String,
+}
+
+pub type HttpResponse = status::Custom<JsonValue>;
+
+pub fn http_ok(data: JsonValue) -> HttpResponse {
+    status::Custom(Status::Ok, json!(data))
+}
+
+pub fn http_err(status: Status, err: String) -> HttpResponse {
+    let body = HttpErrorJson {
+        status: status.code,
+        reason: status.reason.to_string(),
+        message: format!("{}", err),
+    };
+    status::Custom(status, json!(body))
 }
 
 #[get("/")]

--- a/aw-server/src/endpoints/query.rs
+++ b/aw-server/src/endpoints/query.rs
@@ -14,19 +14,8 @@ pub fn query(
     let query_code = query_req.0.query.join("\n");
     let intervals = &query_req.0.timeperiods;
     let mut results = Vec::new();
+    let datastore = endpoints_get_lock!(state.datastore);
     for interval in intervals {
-        // Cannot re-use endpoints_get_lock!() here because it returns Err(Status) on failure and this
-        // function returns HttpResponse
-        let datastore = match state.datastore.lock() {
-            Ok(ds) => ds,
-            Err(e) => {
-                warn!("Taking datastore lock failed, returning 500: {}", e);
-                return Err(HttpErrorJson::new(
-                    Status::ServiceUnavailable,
-                    "Taking datastore lock failed, see aw-server logs".to_string(),
-                ));
-            }
-        };
         let result = match aw_query::query(&query_code, &interval, &datastore) {
             Ok(data) => data,
             Err(e) => {

--- a/aw-server/src/endpoints/query.rs
+++ b/aw-server/src/endpoints/query.rs
@@ -1,63 +1,37 @@
 use rocket::http::Status;
-use rocket::response::status;
 use rocket::State;
-use rocket_contrib::json::{Json, JsonValue};
+use rocket_contrib::json::Json;
 
 use aw_models::Query;
 
-use crate::endpoints::ServerState;
-use aw_query::QueryError;
-
-#[derive(Serialize)]
-struct QueryErrorJson {
-    status: u16,
-    reason: String,
-    message: String,
-}
-
-/* TODO: Slightly ugly code with ok() and error() */
-
-fn ok(data: Vec<aw_query::DataType>) -> status::Custom<JsonValue> {
-    status::Custom(Status::Ok, json!(data))
-}
-
-fn error(err: QueryError) -> status::Custom<JsonValue> {
-    let body = QueryErrorJson {
-        status: 500,
-        reason: "Internal Server Error (Query Error)".to_string(),
-        message: format!("{}", err),
-    };
-    status::Custom(Status::InternalServerError, json!(body))
-}
+use crate::endpoints::{http_err, http_ok, HttpResponse, ServerState};
 
 #[post("/", data = "<query_req>", format = "application/json")]
-pub fn query(query_req: Json<Query>, state: State<ServerState>) -> status::Custom<JsonValue> {
+pub fn query(query_req: Json<Query>, state: State<ServerState>) -> HttpResponse {
     let query_code = query_req.0.query.join("\n");
     let intervals = &query_req.0.timeperiods;
     let mut results = Vec::new();
     for interval in intervals {
         // Cannot re-use endpoints_get_lock!() here because it returns Err(Status) on failure and this
-        // function returns status::Custom
+        // function returns HttpResponse
         let datastore = match state.datastore.lock() {
             Ok(ds) => ds,
             Err(e) => {
                 warn!("Taking datastore lock failed, returning 500: {}", e);
-                let body = QueryErrorJson {
-                    status: 504,
-                    reason: "Service Unavailable".to_string(),
-                    message: "Taking datastore lock failed, see aw-server logs".to_string(),
-                };
-                return status::Custom(Status::ServiceUnavailable, json!(body));
+                return http_err(
+                    Status::ServiceUnavailable,
+                    "Taking datastore lock failed, see aw-server logs".to_string(),
+                );
             }
         };
         let result = match aw_query::query(&query_code, &interval, &datastore) {
             Ok(data) => data,
             Err(e) => {
                 warn!("Query failed: {:?}", e);
-                return error(e);
+                return http_err(Status::InternalServerError, e.to_string());
             }
         };
         results.push(result);
     }
-    ok(results)
+    http_ok(json!(results))
 }

--- a/aw-server/src/endpoints/settings.rs
+++ b/aw-server/src/endpoints/settings.rs
@@ -4,7 +4,7 @@ use rocket::State;
 use rocket_contrib::json::Json;
 use std::sync::MutexGuard;
 
-use aw_datastore::{Datastore, DatastoreError};
+use aw_datastore::Datastore;
 use aw_models::{Key, KeyValue};
 
 use crate::endpoints::HttpErrorJson;
@@ -35,11 +35,7 @@ pub fn setting_set(
 
     match result {
         Ok(_) => Ok(Status::Created),
-        Err(err) => {
-            let err_msg = format!("Unexpected error when creating setting: {:?}", err);
-            warn!("{}", err_msg);
-            Err(HttpErrorJson::new(Status::InternalServerError, err_msg))
-        }
+        Err(err) => Err(err.into()),
     }
 }
 
@@ -48,15 +44,7 @@ pub fn settings_list_get(state: State<ServerState>) -> Result<Json<Vec<Key>>, Ht
     let datastore = endpoints_get_lock!(state.datastore);
     let queryresults = match datastore.get_keys_starting("settings.%") {
         Ok(result) => Ok(result),
-        Err(DatastoreError::NoSuchKey) => Err(HttpErrorJson::new(
-            Status::NotFound,
-            "Key not found".to_string(),
-        )),
-        Err(err) => {
-            let err_msg = format!("Unexpected error when getting setting: {:?}", err);
-            warn!("{}", err_msg);
-            Err(HttpErrorJson::new(Status::InternalServerError, err_msg))
-        }
+        Err(err) => Err(err.into()),
     };
 
     let mut output = Vec::<Key>::new();
@@ -78,15 +66,7 @@ pub fn setting_get(
 
     match datastore.get_key_value(&setting_key) {
         Ok(result) => Ok(Json(result)),
-        Err(DatastoreError::NoSuchKey) => Err(HttpErrorJson::new(
-            Status::NotFound,
-            "Could not find requested key".to_string(),
-        )),
-        Err(err) => {
-            let err_msg = format!("Unexpected error when getting setting: {:?}", err);
-            warn!("{}", err_msg);
-            Err(HttpErrorJson::new(Status::InternalServerError, err_msg))
-        }
+        Err(err) => Err(err.into()),
     }
 }
 
@@ -99,10 +79,6 @@ pub fn setting_delete(state: State<ServerState>, key: String) -> Result<(), Http
 
     match result {
         Ok(_) => Ok(()),
-        Err(err) => {
-            let err_msg = format!("Unexpected error when deleting setting: {:?}", err);
-            warn!("{}", err_msg);
-            Err(HttpErrorJson::new(Status::InternalServerError, err_msg))
-        }
+        Err(err) => Err(err.into()),
     }
 }

--- a/aw-server/src/endpoints/util.rs
+++ b/aw-server/src/endpoints/util.rs
@@ -1,0 +1,80 @@
+use std::io::Cursor;
+
+use rocket::http::ContentType;
+use rocket::http::Status;
+use rocket::request::Request;
+use rocket::response::{self, Responder, Response};
+
+#[derive(Serialize, Debug)]
+pub struct HttpErrorJson {
+    #[serde(skip_serializing)]
+    status: Status,
+    message: String,
+}
+
+impl HttpErrorJson {
+    pub fn new(status: Status, err: String) -> HttpErrorJson {
+        HttpErrorJson {
+            status: status,
+            message: format!("{}", err),
+        }
+    }
+}
+
+impl<'r> Responder<'r> for HttpErrorJson {
+    fn respond_to(self, _: &Request) -> response::Result<'r> {
+        Response::build()
+            .status(self.status)
+            .sized_body(Cursor::new(format!("{{\"message\":\"{}\"}}", self.message)))
+            .header(ContentType::new("application", "json"))
+            .ok()
+    }
+}
+
+use aw_datastore::DatastoreError;
+
+impl Into<HttpErrorJson> for DatastoreError {
+    fn into(self) -> HttpErrorJson {
+        match self {
+            DatastoreError::NoSuchBucket => HttpErrorJson::new(
+                Status::NotFound,
+                "The requested bucket does not exist".to_string(),
+            ),
+            DatastoreError::BucketAlreadyExists => {
+                HttpErrorJson::new(Status::NotModified, "Bucket already exists".to_string())
+            }
+            DatastoreError::NoSuchKey => HttpErrorJson::new(
+                Status::NotFound,
+                "The requested key does not exist".to_string(),
+            ),
+            DatastoreError::MpscError => HttpErrorJson::new(
+                Status::InternalServerError,
+                "Unexpected Mpsc error!".to_string(),
+            ),
+            DatastoreError::InternalError(msg) => {
+                HttpErrorJson::new(Status::InternalServerError, msg)
+            }
+            // When upgrade is disabled
+            DatastoreError::Uninitialized(msg) => {
+                HttpErrorJson::new(Status::InternalServerError, msg)
+            }
+            DatastoreError::OldDbVersion(msg) => {
+                HttpErrorJson::new(Status::InternalServerError, msg)
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! endpoints_get_lock {
+    ( $lock:expr ) => {
+        match $lock.lock() {
+            Ok(r) => r,
+            Err(e) => {
+                let err_msg = format!("Taking datastore lock failed, returning 504: {}", e);
+                warn!("{}", err_msg);
+                return Err(HttpErrorJson::new(Status::ServiceUnavailable, err_msg));
+            }
+        }
+    };
+}

--- a/aw-server/src/lib.rs
+++ b/aw-server/src/lib.rs
@@ -31,6 +31,7 @@ extern crate toml;
 #[macro_use]
 pub mod macros;
 pub mod config;
+pub mod device_id;
 pub mod dirs;
 pub mod endpoints;
 pub mod logging;

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -4,10 +4,8 @@ extern crate getopts;
 
 use getopts::Options;
 use rocket::config::Environment;
-use uuid::Uuid;
 
 use std::env;
-use std::fs;
 
 use aw_server::*;
 
@@ -20,20 +18,6 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 fn print_usage(program: &str, opts: Options) {
     let brief = format!("Usage: {} FILE [options]", program);
     print!("{}", opts.usage(&brief));
-}
-
-/// Retrieves the device ID, if none exists it generates one (using UUID v4)
-fn get_device_id() -> String {
-    // I chose get_data_dir over get_config_dir since the latter isn't yet supported on Android.
-    let mut path = dirs::get_data_dir().unwrap();
-    path.push("device_id");
-    if path.exists() {
-        fs::read_to_string(path).unwrap()
-    } else {
-        let uuid = Uuid::new_v4().to_hyphenated().to_string();
-        fs::write(path, &uuid).unwrap();
-        uuid
-    }
 }
 
 fn main() {
@@ -84,7 +68,7 @@ fn main() {
         // it will not happen there
         datastore: Mutex::new(aw_datastore::Datastore::new(db_path, true)),
         asset_path,
-        device_id: get_device_id(),
+        device_id: device_id::get_device_id(),
     };
 
     endpoints::build_rocket(server_state, config).launch();

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -427,7 +427,7 @@ mod api_tests {
         assert_eq!(res.status(), rocket::http::Status::InternalServerError);
         assert_eq!(
             res.body_string().unwrap(),
-            r#"{"message":"EmptyQuery","reason":"Internal Server Error (Query Error)","status":500}"#
+            r#"{"message":"EmptyQuery","reason":"Internal Server Error","status":500}"#
         );
     }
 

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -89,7 +89,7 @@ mod api_tests {
         assert_eq!(res.status(), rocket::http::Status::NotModified);
         assert_eq!(
             res.body_string().unwrap(),
-            "{\"message\":\"Bucket already exists\"}"
+            r#"{"message":"Bucket 'id' already exists"}"#
         );
 
         // Get list of buckets (1 bucket)
@@ -316,7 +316,7 @@ mod api_tests {
         assert_eq!(res.status(), rocket::http::Status::InternalServerError);
         assert_eq!(
             res.body_string().unwrap(),
-            "{\"message\":\"Failed to import bucket: BucketAlreadyExists\"}"
+            r#"{"message":"Failed to import bucket: BucketAlreadyExists(\"id1\")"}"#
         );
 
         // Export single created bucket

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -26,6 +26,7 @@ mod api_tests {
         let state = endpoints::ServerState {
             datastore: Mutex::new(aw_datastore::Datastore::new_in_memory(false)),
             asset_path: PathBuf::from("aw-webui/dist"),
+            device_id: "test_id".to_string(),
         };
         let aw_config = config::AWConfig::default();
         endpoints::build_rocket(state, aw_config)

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -165,7 +165,7 @@ fn setup_test(sync_directory: &Path) -> std::io::Result<Vec<Datastore>> {
         match ds.create_bucket(&bucket) {
             Ok(()) => (),
             Err(e) => match e {
-                DatastoreError::BucketAlreadyExists => {
+                DatastoreError::BucketAlreadyExists(_) => {
                     debug!("bucket already exists, skipping");
                 }
                 e => panic!("woops! {:?}", e),
@@ -205,7 +205,7 @@ fn get_or_create_sync_bucket(bucket_from: &Bucket, ds_to: &dyn AccessMethod) -> 
 
     match ds_to.get_bucket(new_id.as_str()) {
         Ok(bucket) => bucket,
-        Err(DatastoreError::NoSuchBucket) => {
+        Err(DatastoreError::NoSuchBucket(_)) => {
             let mut bucket_new = bucket_from.clone();
             bucket_new.id = new_id.clone();
             // TODO: Replace sync origin with hostname/GUID and discuss how we will treat the data

--- a/aw-sync/tests/sync.rs
+++ b/aw-sync/tests/sync.rs
@@ -39,7 +39,7 @@ mod sync_tests {
         match ds.create_bucket(&bucket) {
             Ok(()) => (),
             Err(e) => match e {
-                DatastoreError::BucketAlreadyExists => {
+                DatastoreError::BucketAlreadyExists(_) => {
                     debug!("bucket already exists, skipping");
                 }
                 e => panic!("woops! {:?}", e),


### PR DESCRIPTION
- Make UUID no longer be re-read from file on each /info request
- More testing
- Make all endpoints return a HttpErrorJson which has a "message" field with a descriptive error
    - Can hopefully in the future be used in the web-ui to better describe what goes wrong in case of for example an import without having to look at the server log
    - Will hopefully make the future swagger ui look nice
- Implement the "Into" trait for DatastoreError to HttpErrorJson to be able to remove a lot of boilerplate code