### PR TITLE
Make settings value possibly any json type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,9 +510,9 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c53dc3a653e0f64081026e4bf048d48fec9fce90c66e8326ca7292df0ff2d82"
+checksum = "d55796afa1b20c2945ca8eabfc421839f2b766619209f1ede813cf2484f31804"
 
 [[package]]
 name = "encoding_rs"
@@ -652,51 +652,51 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a4d35f7401e948629c9c3d6638fb9bf94e0b2121e96c3b428cc4e631f3eb74"
+checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d674eaa0056896d5ada519900dbf97ead2e46a7b6621e8160d79e2f2e1e2784b"
+checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
 
 [[package]]
 name = "futures-io"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc94b64bb39543b4e432f1790b6bf18e3ee3b74653c5449f63310e9a74b123c"
+checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8764258ed64ebc5d9ed185cf86a95db5cac810269c5d20ececb32e0088abbd"
+checksum = "0e3ca3f17d6e8804ae5d3df7a7d35b2b3a6fe89dac84b31872720fc3060a0b11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd26820a9f3637f1302da8bceba3ff33adbe53464b54ca24d4e2d4f1db30f94"
+checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a894a0acddba51a2d49a6f4263b1e64b8c579ece8af50fa86503d52cd1eea34"
+checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
 dependencies = [
  "futures-core",
  "futures-io",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project 1.0.1",
  "pin-utils",
  "slab",
 ]
@@ -757,9 +757,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
  "bytes",
  "fnv",
@@ -772,6 +772,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -889,7 +890,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project 0.4.27",
  "socket2",
  "tokio",
  "tower-service",
@@ -1069,9 +1070,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1116,9 +1117,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "mime"
@@ -1396,7 +1397,16 @@ version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 0.4.27",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+dependencies = [
+ "pin-project-internal 1.0.1",
 ]
 
 [[package]]
@@ -1407,14 +1417,25 @@ checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.44",
+ "syn 1.0.48",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
+checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-utils"
@@ -1886,7 +1907,7 @@ dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "serde_derive_internals",
- "syn 1.0.44",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -1929,7 +1950,7 @@ checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.44",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -1940,7 +1961,7 @@ checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.44",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -2014,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
+checksum = "3015a7d0a5fd5105c91c3710d42f9ccf0abfb287d62206484dcc67f9569a6483"
 
 [[package]]
 name = "subtle"
@@ -2043,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.44"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03e57e4fcbfe7749842d53e24ccb9aa12b7252dbe5e91d2acad31834c8b8fdd"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2177,6 +2198,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project 0.4.27",
+ "tracing",
 ]
 
 [[package]]
@@ -2398,7 +2429,7 @@ dependencies = [
  "log 0.4.11",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.44",
+ "syn 1.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -2432,7 +2463,7 @@ checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.44",
+ "syn 1.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/aw-models/src/key_value.rs
+++ b/aw-models/src/key_value.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct Key {
@@ -10,12 +11,16 @@ pub struct Key {
 #[derive(Serialize, Deserialize, JsonSchema, Clone, Debug, PartialEq)]
 pub struct KeyValue {
     pub key: String,
-    pub value: String,
+    pub value: Value,
     pub timestamp: Option<DateTime<Utc>>,
 }
 
 impl KeyValue {
-    pub fn new<T: Into<String>>(key: T, value: T, timestamp: DateTime<Utc>) -> KeyValue {
+    pub fn new<K: Into<String>, V: Into<Value>>(
+        key: K,
+        value: V,
+        timestamp: DateTime<Utc>,
+    ) -> KeyValue {
         KeyValue {
             key: key.into(),
             value: value.into(),

--- a/aw-server/src/endpoints/settings.rs
+++ b/aw-server/src/endpoints/settings.rs
@@ -31,7 +31,7 @@ pub fn setting_set(
     let setting_key = parse_key(data.key)?;
 
     let datastore: MutexGuard<'_, Datastore> = endpoints_get_lock!(state.datastore);
-    let result = datastore.insert_key_value(&setting_key, &data.value);
+    let result = datastore.insert_key_value(&setting_key, &data.value.to_string());
 
     match result {
         Ok(_) => Ok(Status::Created),

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -14,6 +14,7 @@ mod api_tests {
 
     use chrono::{DateTime, Utc};
     use rocket::http::{ContentType, Header, Status};
+    use serde_json::{json, Value};
 
     use aw_server::config;
     use aw_server::endpoints;
@@ -459,10 +460,10 @@ mod api_tests {
         assert_eq!(res.body_string().unwrap(), r#"{"message":"EmptyQuery"}"#);
     }
 
-    fn set_setting_request(client: &Client, key: &str, value: &str) -> Status {
+    fn set_setting_request(client: &Client, key: &str, value: Value) -> Status {
         let body = serde_json::to_string(&KeyValue {
             key: key.to_string(),
-            value: value.to_string(),
+            value: value,
             timestamp: None,
         })
         .unwrap();
@@ -500,7 +501,7 @@ mod api_tests {
         let client = rocket::local::Client::new(server).expect("valid instance");
 
         // Test getting not found (getting nonexistent key)
-        let res = set_setting_request(&client, "thisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongk", "");
+        let res = set_setting_request(&client, "thisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongkthisisaverylongk", json!(""));
         assert_eq!(res, rocket::http::Status::BadRequest);
     }
 
@@ -510,7 +511,7 @@ mod api_tests {
         let client = rocket::local::Client::new(server).expect("valid instance");
 
         // Test value creation
-        let response_status = set_setting_request(&client, "test_key", "test_value");
+        let response_status = set_setting_request(&client, "test_key", json!("test_value"));
         assert_eq!(response_status, rocket::http::Status::Created);
     }
 
@@ -529,9 +530,9 @@ mod api_tests {
         let server = setup_testserver();
         let client = rocket::local::Client::new(server).expect("valid instance");
 
-        let response1_status = set_setting_request(&client, "test_key", "");
+        let response1_status = set_setting_request(&client, "test_key", json!(""));
         assert_eq!(response1_status, rocket::http::Status::Created);
-        let response2_status = set_setting_request(&client, "test_key_2", "");
+        let response2_status = set_setting_request(&client, "test_key_2", json!(""));
         assert_eq!(response2_status, rocket::http::Status::Created);
 
         let mut res = client.get("/api/0/settings/").dispatch();
@@ -549,7 +550,7 @@ mod api_tests {
         let client = rocket::local::Client::new(server).expect("valid instance");
 
         let timestamp = Utc::now();
-        let response_status = set_setting_request(&client, "test_key", "test_value");
+        let response_status = set_setting_request(&client, "test_key", json!("test_value"));
         assert_eq!(response_status, rocket::http::Status::Created);
 
         // Test getting
@@ -569,7 +570,7 @@ mod api_tests {
         let client = rocket::local::Client::new(server).expect("valid instance");
 
         let timestamp = Utc::now();
-        let post_1_status = set_setting_request(&client, "test_key", "test_value");
+        let post_1_status = set_setting_request(&client, "test_key", json!("test_value"));
         assert_eq!(post_1_status, rocket::http::Status::Created);
 
         let mut res = client.get("/api/0/settings/test_key").dispatch();
@@ -583,7 +584,7 @@ mod api_tests {
         );
 
         let timestamp_2 = Utc::now();
-        let post_2_status = set_setting_request(&client, "test_key", "changed_test_value");
+        let post_2_status = set_setting_request(&client, "test_key", json!("changed_test_value"));
         assert_eq!(post_2_status, rocket::http::Status::Created);
 
         let mut res = client.get("/api/0/settings/test_key").dispatch();
@@ -602,7 +603,7 @@ mod api_tests {
         let server = setup_testserver();
         let client = rocket::local::Client::new(server).expect("valid instance");
 
-        let response_status = set_setting_request(&client, "test_key", "");
+        let response_status = set_setting_request(&client, "test_key", json!(""));
         assert_eq!(response_status, rocket::http::Status::Created);
 
         // Test deleting

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -565,6 +565,48 @@ mod api_tests {
     }
 
     #[test]
+    fn test_getting_setting_multiple_types() {
+        let server = setup_testserver();
+        let client = rocket::local::Client::new(server).expect("valid instance");
+
+        let timestamp = Utc::now();
+
+        // Test array
+        let response_status = set_setting_request(&client, "test_key_array", json!("[1,2,3]"));
+        assert_eq!(response_status, rocket::http::Status::Created);
+
+        let mut res = client.get("/api/0/settings/test_key_array").dispatch();
+        assert_eq!(res.status(), rocket::http::Status::Ok);
+        let deserialized: KeyValue = serde_json::from_str(&res.body_string().unwrap()).unwrap();
+        _equal_and_timestamp_in_range(
+            timestamp,
+            deserialized,
+            KeyValue::new("settings.test_key_array", "[1,2,3]", Utc::now()),
+        );
+
+        // Test dict
+        let response_status = set_setting_request(
+            &client,
+            "test_key_dict",
+            json!("{key: 'value', another_key: 'another value'}"),
+        );
+        assert_eq!(response_status, rocket::http::Status::Created);
+
+        let mut res = client.get("/api/0/settings/test_key_dict").dispatch();
+        assert_eq!(res.status(), rocket::http::Status::Ok);
+        let deserialized: KeyValue = serde_json::from_str(&res.body_string().unwrap()).unwrap();
+        _equal_and_timestamp_in_range(
+            timestamp,
+            deserialized,
+            KeyValue::new(
+                "settings.test_key_dict",
+                "{key: 'value', another_key: 'another value'}",
+                Utc::now(),
+            ),
+        );
+    }
+
+    #[test]
     fn test_updating_setting() {
         let server = setup_testserver();
         let client = rocket::local::Client::new(server).expect("valid instance");


### PR DESCRIPTION
Before it was forced to be a string

We should probably discuss this a little further before merging. @ErikBjare and @xylix, what do you think?

Pros:
- Client can send any JSON type and not only string, doesn't have to manually deserialize json within the string if it wants to use some other type than string

Cons:
- The datastore now contains serialized JSON rather than just a string

Fixes #178 