### PR TITLE
fix: correct lookup of asset_path for .app bundles on macOS

### DIFF
--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -119,6 +119,7 @@ fn get_asset_path() -> PathBuf {
     // Search order for asset path is:
     // 1. ./aw-webui/dist
     // 2. $current_exe_dir/aw_server_rust/static
+    //    NOTE: Slightly different for .app bundles on macOS
     // 3. $XDG_DATA_DIR/aw_server_rust/static
     // 4. (fallback) ./aw-webui/dist
 
@@ -134,6 +135,19 @@ fn get_asset_path() -> PathBuf {
     if let Ok(mut current_exe_path) = current_exe() {
         current_exe_path.pop(); // remove name of executable
         current_exe_path.push("./static/");
+        if current_exe_path.as_path().exists() {
+            return current_exe_path;
+        }
+    }
+
+    // For .app bundles on macOS
+    //
+    // On macOS, the executable location is ActivityWatch.app/Contents/MacOS/aw-server-rust,
+    // and the webui location is ActivityWatch.app/Contents/Resources/aw_server_rust/static.
+    if let Ok(mut current_exe_path) = current_exe() {
+        current_exe_path.pop(); // remove name of executable
+        current_exe_path.pop(); // step up into the Contents directory
+        current_exe_path.push("Resources/aw_server_rust/static/");
         if current_exe_path.as_path().exists() {
             return current_exe_path;
         }


### PR DESCRIPTION
Needed for https://github.com/ActivityWatch/activitywatch/pull/506