### PR TITLE
fix: corrected non-standard log dir on macOS (fixes #187)

### DIFF
--- a/aw-server/src/dirs.rs
+++ b/aw-server/src/dirs.rs
@@ -54,10 +54,9 @@ pub fn get_cache_dir() -> Result<PathBuf, ()> {
 
 #[cfg(not(target_os = "android"))]
 pub fn get_log_dir() -> Result<PathBuf, ()> {
-    let mut dir = appdirs::user_cache_dir(Some("activitywatch"), None)?;
-    dir.push("log");
+    let mut dir = appdirs::user_log_dir(Some("activitywatch"), None)?;
     dir.push("aw-server-rust");
-    fs::create_dir_all(dir.clone()).expect("Unable to create cache dir");
+    fs::create_dir_all(dir.clone()).expect("Unable to create log dir");
     Ok(dir)
 }
 


### PR DESCRIPTION
appdirs does this right.

Behaves the same as before on UNIX: https://docs.rs/appdirs/0.2.0/src/appdirs/lib.rs.html#139-145

Behaves correctly on macOS: https://docs.rs/appdirs/0.2.0/src/appdirs/lib.rs.html#58-61