### PR TITLE
ci: switched to source-based coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,9 @@ jobs:
         key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
           ${{ runner.os }}-${{ env.cache-name }}-
+    - name:  Install llvm-tools
+      run: |
+        rustup component add llvm-tools-preview
     - name: Download grcov
       run: |
         curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-linux-x86_64.tar.bz2 | tar jxf -
@@ -67,7 +70,7 @@ jobs:
         export PATH=$PATH:.
         make coverage-lcov COVERAGE_CACHE=1
     - name: Upload coverage files
-      run: bash <(curl -s https://codecov.io/bash);
+      run: bash <(curl -s https://codecov.io/bash) -f target/debug/lcov.info;
 
   build-android:
     name: Build for Android

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-/target/
+target
 **/*.rs.bk
 NDK
 .cargo/config
 *.zip
+*.profraw

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,6 @@ endif
 test:
 	cargo test
 
-
-COV_CARGO_INCREMENTAL=0
-COV_RUSTFLAGS="-Zinstrument-coverage"
-COV_RUSTDOCFLAGS="-Cpanic=abort"
-
 test-coverage:
 ifndef COVERAGE_CACHE
 	# We need to remove build files in case a non-coverage test has been run
@@ -39,9 +34,7 @@ ifndef COVERAGE_CACHE
 endif
 	rm -rf **/*.profraw
 	# Build and test
-	env CARGO_INCREMENTAL=${COV_CARGO_INCREMENTAL} \
-	    RUSTFLAGS=${COV_RUSTFLAGS} \
-	    RUSTDOCFLAGS=${COV_RUSTDOCFLAGS} \
+	env RUSTFLAGS="-Zinstrument-coverage" \
 	    LLVM_PROFILE_FILE="grcov-%p-%m.profraw" \
 	    cargo test --verbose
 


### PR DESCRIPTION
Largely based on how grcov themselves do it: https://github.com/mozilla/grcov/blob/master/.travis.yml

From https://github.com/mozilla/grcov/commit/e98d5ddc6570a9f4b6d113b6931fec53357c064b, it seems we can go even further and remove `CARGO_INCREMENTAL` and `RUSTDOCFLAGS`.

Hopefully helps with #189 

Screenshot of HTML report when I run locally. Note that ~~source-based coverage~~ grcov doesn't support branch coverage (I asked them about it in https://github.com/mozilla/grcov/issues/520):

![image](https://user-images.githubusercontent.com/1405370/100346053-862b5300-2fe3-11eb-9e70-f1dc78b59082.png)
