### PR TITLE
aw-server: Disable jemalloc on non-x86 CPUs

### DIFF
--- a/aw-server/Cargo.toml
+++ b/aw-server/Cargo.toml
@@ -38,7 +38,7 @@ aw-query = { path = "../aw-query" }
 [target.'cfg(target_os="linux")'.dependencies]
 jemallocator = "0.3.2"
 
-[target.'cfg(target_os="android")'.dependencies]
+[target.'cfg(all(target_os="android", target_arch="x86"))'.dependencies]
 jni = { version = "0.18", default-features = false }
 libc = "0.2"
 android_logger = "0.9"

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -9,9 +9,9 @@ use std::env;
 
 use aw_server::*;
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_arch = "x86"))]
 extern crate jemallocator;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", target_arch = "x86"))]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
jemalloc is only properly tested on x86 on Linux and doesn't even compile for aarch64 it seems.
Needed for aw-server to compile for Linux phones such as PinePhone and Librem 5.