### PR TITLE
aw-datastore: Fix broken legacy import on Windows

### DIFF
--- a/aw-datastore/src/legacy_import.rs
+++ b/aw-datastore/src/legacy_import.rs
@@ -34,7 +34,7 @@ mod import {
     use super::LegacyDatastoreImportError;
 
     fn dbfile_path() -> PathBuf {
-        let mut dir = appdirs::user_data_dir(Some("activitywatch"), None, false).unwrap();
+        let mut dir = appdirs::user_data_dir(Some("activitywatch"), Some("activitywatch"), false).unwrap();
         dir.push("aw-server");
         dir.push("peewee-sqlite.v2.db");
         dir
@@ -157,6 +157,7 @@ mod import {
     ) -> Result<(), LegacyDatastoreImportError> {
         let legacy_db_path = dbfile_path();
         if !legacy_db_path.exists() {
+            info!("Did not find an old database, skipping legacy import");
             return Ok(());
         }
         info!("Importing legacy DB");


### PR DESCRIPTION
Since the "author" field was not passed to appdirs, the old aw-server folder was not correctly set for the old aw-server database and therefore skipped.