### PR TITLE
test: added tests for datastore query of events that cover the queried range

### DIFF
--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -792,7 +792,8 @@ impl DatastoreInstance {
             "
             SELECT count(*) FROM events
             WHERE bucketrow = ?1
-                AND (starttime >= ?2 OR endtime <= ?3)",
+                AND endtime >= ?2 
+                AND starttime <= ?3",
         ) {
             Ok(stmt) => stmt,
             Err(err) => {


### PR DESCRIPTION
Initially thought this was broken, but it wasn't (only for `get_eventcount`). Added a test for it anyway.