### PR TITLE
feat: added hostname filtering support to find_bucket

### DIFF
--- a/aw-query/tests/query.rs
+++ b/aw-query/tests/query.rs
@@ -351,7 +351,7 @@ mod query_tests {
 
         let code = format!(
             r#"
-            events = query_bucket(find_bucket("{}"));
+            events = query_bucket(find_bucket("{}", "testhost"));
             events = flood(events);
             events = sort_by_duration(events);
             events = limit_events(events, 10000);


### PR DESCRIPTION
This functionality was available in aw-core. 

Needed for new queries which don't assume a certain bucket ID containing the hostname.

Also needed for my PR in https://github.com/ErikBjare/quantifiedme/pull/4