### PR TITLE
another sync PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 target
-**/*.rs.bk
-NDK
 .cargo/config
+NDK
+
+**/*.rs.bk
 *.zip
 *.profraw
+
+*.sqlite*
+*.db
+*.db-journal

--- a/aw-client-rust/src/lib.rs
+++ b/aw-client-rust/src/lib.rs
@@ -23,7 +23,10 @@ pub struct AwClient {
 impl AwClient {
     pub fn new(ip: &str, port: &str, name: &str) -> AwClient {
         let baseurl = format!("http://{}:{}", ip, port);
-        let client = reqwest::blocking::Client::new();
+        let client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .unwrap();
         let hostname = gethostname::gethostname().into_string().unwrap();
         AwClient {
             client,

--- a/aw-client-rust/src/lib.rs
+++ b/aw-client-rust/src/lib.rs
@@ -12,12 +12,17 @@ use serde_json::Map;
 
 pub use aw_models::{Bucket, BucketMetadata, Event};
 
-#[derive(Debug)]
 pub struct AwClient {
     client: reqwest::blocking::Client,
     pub baseurl: String,
     pub name: String,
     pub hostname: String,
+}
+
+impl std::fmt::Debug for AwClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "AwClient(baseurl={:?})", self.baseurl)
+    }
 }
 
 impl AwClient {

--- a/aw-client-rust/tests/test.rs
+++ b/aw-client-rust/tests/test.rs
@@ -76,7 +76,9 @@ mod test {
 
         let bucketname = format!("aw-client-rust-test_{}", client.hostname);
         let buckettype = "test-type";
-        client.create_bucket(&bucketname, &buckettype).unwrap();
+        client
+            .create_bucket_simple(&bucketname, &buckettype)
+            .unwrap();
 
         let bucket = client.get_bucket(&bucketname).unwrap();
         assert!(bucket.id == bucketname);

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -6,6 +6,8 @@ use chrono::NaiveDateTime;
 use chrono::Utc;
 
 use rusqlite::Connection;
+use rusqlite::Transaction;
+use rusqlite::TransactionBehavior;
 
 use serde_json::value::Value;
 

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -6,8 +6,6 @@ use chrono::NaiveDateTime;
 use chrono::Utc;
 
 use rusqlite::Connection;
-use rusqlite::Transaction;
-use rusqlite::TransactionBehavior;
 
 use serde_json::value::Value;
 

--- a/aw-datastore/src/lib.rs
+++ b/aw-datastore/src/lib.rs
@@ -22,6 +22,7 @@ mod worker;
 pub use self::datastore::DatastoreInstance;
 pub use self::worker::Datastore;
 
+#[derive(Debug, Clone)]
 pub enum DatastoreMethod {
     Memory(),
     File(String),

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -27,6 +27,7 @@ struct Opts {
     #[clap(long)]
     port: Option<String>,
     /// Path to database override
+    /// Also implies --no-legacy-import if no db found
     #[clap(long)]
     dbpath: Option<String>,
     /// Device ID override
@@ -66,7 +67,7 @@ async fn main() -> Result<(), rocket::Error> {
     }
 
     // Set db path if overridden
-    let db_path: String = if let Some(dbpath) = opts.dbpath {
+    let db_path: String = if let Some(dbpath) = opts.dbpath.clone() {
         dbpath
     } else {
         dirs::db_path(testing)
@@ -80,7 +81,11 @@ async fn main() -> Result<(), rocket::Error> {
     let asset_path = get_asset_path();
     info!("Using aw-webui assets at path {:?}", asset_path);
 
-    let legacy_import = !opts.no_legacy_import;
+    // Only use legacy import if opts.dbpath is not set
+    let legacy_import = !opts.no_legacy_import && opts.dbpath.is_none();
+    if opts.dbpath.is_some() {
+        info!("Since custom dbpath is set, --no-legacy-import is implied");
+    }
 
     let device_id: String = if let Some(id) = opts.device_id {
         id

--- a/aw-sync/Cargo.toml
+++ b/aw-sync/Cargo.toml
@@ -9,7 +9,7 @@ name = "aw_sync"
 path = "src/lib.rs"
 
 [[bin]]
-name = "aw-sync-rust"
+name = "aw-sync"
 path = "src/main.rs"
 
 [dependencies]

--- a/aw-sync/README.md
+++ b/aw-sync/README.md
@@ -8,13 +8,22 @@ Works by syncing local buckets with a special folder, which in turn should be sy
 
 ## Usage
 
+TODO: Write usage instructions for how to use with a normal testing/staging (5666) instance, to actually sync between devices.
+
+```
+cargo run --bin aw-sync-rust -- --port 5666 --help
+```
+
+
+## Testing
+
 **Note:** this documents usage for testing, it is not yet ready for production usage.
+
+It assumes you're running temporary aw-server instances.
 
 ### Pushing to the sync directory
 
-First start your aw-server instance. 
-
-For example: 
+First start the sending aw-server instance. For example: 
 
 ```sh
 PORT=5667
@@ -27,7 +36,9 @@ Then run `cargo run --bin aw-sync-rust -- --port 5667` to sync your instance's b
 
 ### Pulling from the sync directory
 
-Now to sync things back from the sync directory onto another instance. First, lets start another instance:
+Now to sync things back from the sync directory into another instance. 
+
+First, lets start another instance:
 
 ```sh
 PORT=5668

--- a/aw-sync/src/accessmethod.rs
+++ b/aw-sync/src/accessmethod.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+
+use aw_client_rust::AwClient;
+use chrono::{DateTime, Utc};
+use reqwest::StatusCode;
+
+use aw_datastore::{Datastore, DatastoreError};
+use aw_models::{Bucket, Event};
+
+// This trait should be implemented by both AwClient and Datastore, unifying them under a single API
+pub trait AccessMethod: std::fmt::Debug {
+    fn get_buckets(&self) -> Result<HashMap<String, Bucket>, String>;
+    fn get_bucket(&self, bucket_id: &str) -> Result<Bucket, DatastoreError>;
+    fn create_bucket(&self, bucket: &Bucket) -> Result<(), DatastoreError>;
+    fn get_events(
+        &self,
+        bucket_id: &str,
+        start: Option<DateTime<Utc>>,
+        end: Option<DateTime<Utc>>,
+        limit: Option<u64>,
+    ) -> Result<Vec<Event>, String>;
+    fn insert_events(&self, bucket_id: &str, events: Vec<Event>) -> Result<Vec<Event>, String>;
+    fn get_event_count(&self, bucket_id: &str) -> Result<i64, String>;
+    fn heartbeat(&self, bucket_id: &str, event: Event, duration: f64) -> Result<(), String>;
+}
+
+impl AccessMethod for Datastore {
+    fn get_buckets(&self) -> Result<HashMap<String, Bucket>, String> {
+        Ok(self.get_buckets().unwrap())
+    }
+    fn get_bucket(&self, bucket_id: &str) -> Result<Bucket, DatastoreError> {
+        self.get_bucket(bucket_id)
+    }
+    fn create_bucket(&self, bucket: &Bucket) -> Result<(), DatastoreError> {
+        self.create_bucket(bucket)?;
+        self.force_commit().unwrap();
+        Ok(())
+    }
+    fn get_events(
+        &self,
+        bucket_id: &str,
+        start: Option<DateTime<Utc>>,
+        end: Option<DateTime<Utc>>,
+        limit: Option<u64>,
+    ) -> Result<Vec<Event>, String> {
+        Ok(self.get_events(bucket_id, start, end, limit).unwrap())
+    }
+    fn heartbeat(&self, bucket_id: &str, event: Event, duration: f64) -> Result<(), String> {
+        self.heartbeat(bucket_id, event, duration).unwrap();
+        self.force_commit().unwrap();
+        Ok(())
+    }
+    fn insert_events(&self, bucket_id: &str, events: Vec<Event>) -> Result<Vec<Event>, String> {
+        let res = self.insert_events(bucket_id, &events[..]).unwrap();
+        self.force_commit().unwrap();
+        Ok(res)
+    }
+    fn get_event_count(&self, bucket_id: &str) -> Result<i64, String> {
+        Ok(self.get_event_count(bucket_id, None, None).unwrap())
+    }
+}
+
+impl AccessMethod for AwClient {
+    fn get_buckets(&self) -> Result<HashMap<String, Bucket>, String> {
+        Ok(self.get_buckets().unwrap())
+    }
+    fn get_bucket(&self, bucket_id: &str) -> Result<Bucket, DatastoreError> {
+        let bucket = self.get_bucket(bucket_id);
+        match bucket {
+            Ok(bucket) => Ok(bucket),
+            Err(e) => {
+                warn!("{:?}", e);
+                let code = e.status().unwrap();
+                if code == StatusCode::NOT_FOUND {
+                    Err(DatastoreError::NoSuchBucket(bucket_id.into()))
+                } else {
+                    panic!("Unexpected error");
+                }
+            }
+        }
+    }
+    fn get_events(
+        &self,
+        bucket_id: &str,
+        start: Option<DateTime<Utc>>,
+        end: Option<DateTime<Utc>>,
+        limit: Option<u64>,
+    ) -> Result<Vec<Event>, String> {
+        Ok(self.get_events(bucket_id, start, end, limit).unwrap())
+    }
+    fn insert_events(&self, _bucket_id: &str, _events: Vec<Event>) -> Result<Vec<Event>, String> {
+        //Ok(self.insert_events(bucket_id, &events[..]).unwrap())
+        Err("Not implemented".to_string())
+    }
+    fn get_event_count(&self, bucket_id: &str) -> Result<i64, String> {
+        Ok(self.get_event_count(bucket_id).unwrap())
+    }
+    fn create_bucket(&self, bucket: &Bucket) -> Result<(), DatastoreError> {
+        self.create_bucket(bucket.id.as_str(), bucket._type.as_str())
+            .unwrap();
+        Ok(())
+        //Err(DatastoreError::InternalError("Not implemented".to_string()))
+    }
+    fn heartbeat(&self, bucket_id: &str, event: Event, duration: f64) -> Result<(), String> {
+        self.heartbeat(bucket_id, &event, duration)
+            .map_err(|e| format!("{:?}", e))
+    }
+}

--- a/aw-sync/src/accessmethod.rs
+++ b/aw-sync/src/accessmethod.rs
@@ -22,6 +22,7 @@ pub trait AccessMethod: std::fmt::Debug {
     fn insert_events(&self, bucket_id: &str, events: Vec<Event>) -> Result<Vec<Event>, String>;
     fn get_event_count(&self, bucket_id: &str) -> Result<i64, String>;
     fn heartbeat(&self, bucket_id: &str, event: Event, duration: f64) -> Result<(), String>;
+    fn close(&self);
 }
 
 impl AccessMethod for Datastore {
@@ -57,6 +58,9 @@ impl AccessMethod for Datastore {
     }
     fn get_event_count(&self, bucket_id: &str) -> Result<i64, String> {
         Ok(self.get_event_count(bucket_id, None, None).unwrap())
+    }
+    fn close(&self) {
+        self.close();
     }
 }
 
@@ -104,5 +108,8 @@ impl AccessMethod for AwClient {
     fn heartbeat(&self, bucket_id: &str, event: Event, duration: f64) -> Result<(), String> {
         self.heartbeat(bucket_id, &event, duration)
             .map_err(|e| format!("{:?}", e))
+    }
+    fn close(&self) {
+        // NOP
     }
 }

--- a/aw-sync/src/lib.rs
+++ b/aw-sync/src/lib.rs
@@ -7,6 +7,7 @@ extern crate serde_json;
 mod sync;
 pub use sync::sync_datastores;
 pub use sync::sync_run;
+pub use sync::SyncSpec;
 
 mod accessmethod;
 pub use accessmethod::AccessMethod;

--- a/aw-sync/src/lib.rs
+++ b/aw-sync/src/lib.rs
@@ -7,3 +7,6 @@ extern crate serde_json;
 mod sync;
 pub use sync::sync_datastores;
 pub use sync::sync_run;
+
+mod accessmethod;
+pub use accessmethod::AccessMethod;

--- a/aw-sync/src/lib.rs
+++ b/aw-sync/src/lib.rs
@@ -5,6 +5,7 @@ extern crate serde;
 extern crate serde_json;
 
 mod sync;
+pub use sync::create_datastore;
 pub use sync::sync_datastores;
 pub use sync::sync_run;
 pub use sync::SyncSpec;

--- a/aw-sync/src/main.rs
+++ b/aw-sync/src/main.rs
@@ -1,3 +1,12 @@
+// What needs to be done:
+//  - [x] Setup local sync bucket
+//  - [x] Import local buckets and sync events from aw-server (either through API or through creating a read-only Datastore)
+//  - [x] Import buckets and sync events from remotes
+//  - [ ] Add CLI arguments
+//     - [x] For which local server to use
+//     - [x] For which sync dir to use
+//     - [ ] Date to start syncing from
+
 #[macro_use]
 extern crate log;
 extern crate chrono;
@@ -6,11 +15,14 @@ extern crate serde_json;
 
 use std::path::Path;
 
+use chrono::{DateTime, Utc};
 use clap::Parser;
 
 use aw_client_rust::AwClient;
 
 mod sync;
+
+const DEFAULT_PORT: &str = "5600";
 
 #[derive(Parser)]
 #[clap(version = "0.1", author = "Erik Bjäreholt")]
@@ -19,35 +31,64 @@ struct Opts {
     #[clap(long, default_value = "127.0.0.1")]
     host: String,
     /// Port of instance to connect to
-    #[clap(long, default_value = "5666")]
+    #[clap(long, default_value = DEFAULT_PORT)]
     port: String,
+    /// Convenience option for using the default testing host and port.
+    #[clap(long)]
+    testing: bool,
+    /// Path to sync directory
+    /// If not specified, exit
+    #[clap(long)]
+    sync_dir: String,
+    /// Date to start syncing from
+    /// If not specified, start from beginning
+    /// NOTE: might be unstable, as count cannot be used to verify integrity of sync.
+    /// Format: YYYY-MM-DD
+    #[clap(long)]
+    start_date: Option<String>,
+    /// Specify buckets to sync
+    /// If not specified, all buckets will be synced
+    #[clap(long)]
+    buckets: Vec<String>,
 }
 
-fn main() {
-    // What needs to be done:
-    //  - [x] Setup local sync bucket
-    //  - [x] Import local buckets and sync events from aw-server (either through API or through creating a read-only Datastore)
-    //  - [x] Import buckets and sync events from remotes
-    //  - [ ] Add CLI arguments
-    //     - [ ] For which local server to use
-    //     - [ ] For which sync dir to use
-
+fn main() -> std::io::Result<()> {
     let opts: Opts = Opts::parse();
 
     println!("Started aw-sync-rust...");
 
     aw_server::logging::setup_logger(true).expect("Failed to setup logging");
 
-    // TODO: Get path using dirs module
-    let sync_directory = Path::new("sync-testing");
+    let sync_directory = if opts.sync_dir.is_empty() {
+        println!("No sync directory specified, exiting...");
+        std::process::exit(1);
+    } else {
+        Path::new(&opts.sync_dir)
+    };
 
-    let client = AwClient::new(opts.host.as_str(), opts.port.as_str(), "aw-sync-rust");
+    let port = if opts.testing && opts.port == DEFAULT_PORT {
+        "5666"
+    } else {
+        &opts.port
+    };
 
-    sync::sync_run(sync_directory, client);
+    let client = AwClient::new(opts.host.as_str(), port, "aw-sync-rust");
+
+    let start: Option<DateTime<Utc>> = opts.start_date.map(|date| {
+        chrono::DateTime::parse_from_rfc3339(&date)
+            .unwrap()
+            .with_timezone(&chrono::Utc)
+    });
+    sync::sync_run(sync_directory, client, opts.buckets, start).map_err(|e| {
+        println!("Error: {}", e);
+        std::io::Error::new(std::io::ErrorKind::Other, e)
+    })?;
     info!("Finished successfully, exiting...");
 
     // Needed to give the datastores some time to commit before program is shut down.
     // 100ms isn't actually needed, seemed to work fine with as little as 10ms, but I'd rather give
     // it some wiggleroom.
     std::thread::sleep(std::time::Duration::from_millis(100));
+
+    Ok(())
 }

--- a/aw-sync/src/main.rs
+++ b/aw-sync/src/main.rs
@@ -65,6 +65,10 @@ enum Commands {
         /// If not specified, all buckets will be synced.
         #[clap(long)]
         buckets: Option<String>,
+        /// Mode to sync in. Can be "push", "pull", or "both".
+        /// Defaults to "both".
+        #[clap(long, default_value = "both")]
+        mode: String,
     },
     /// List buckets and their sync status.
     List {},
@@ -98,6 +102,7 @@ fn main() -> std::io::Result<()> {
         Commands::Sync {
             start_date,
             buckets,
+            mode,
         } => {
             let start: Option<DateTime<Utc>> = start_date.as_ref().map(|date| {
                 println!("{}", date.clone());
@@ -120,11 +125,17 @@ fn main() -> std::io::Result<()> {
                 start,
             };
 
-            sync::sync_run(client, &sync_spec).map_err(|e| {
+            let mode_enum = match mode.as_str() {
+                "push" => sync::SyncMode::Push,
+                "pull" => sync::SyncMode::Pull,
+                "both" => sync::SyncMode::Both,
+                _ => panic!("Invalid mode"),
+            };
+
+            sync::sync_run(client, &sync_spec, mode_enum).map_err(|e| {
                 println!("Error: {}", e);
                 std::io::Error::new(std::io::ErrorKind::Other, e)
             })?;
-            info!("Finished successfully, exiting...");
             Ok(())
         }
 

--- a/aw-sync/src/main.rs
+++ b/aw-sync/src/main.rs
@@ -60,7 +60,7 @@ enum Commands {
         /// Specify buckets to sync
         /// If not specified, all buckets will be synced
         #[clap(long)]
-        buckets: Vec<String>,
+        buckets: Option<Vec<String>>,
     },
     /// List buckets and their sync status
     List {},
@@ -100,8 +100,13 @@ fn main() -> std::io::Result<()> {
                     .unwrap()
                     .with_timezone(&chrono::Utc)
             });
+            let sync_spec = sync::SyncSpec {
+                path: sync_directory.to_path_buf(),
+                buckets: buckets.clone(),
+                start,
+            };
 
-            sync::sync_run(sync_directory, client, buckets, start).map_err(|e| {
+            sync::sync_run(client, &sync_spec).map_err(|e| {
                 println!("Error: {}", e);
                 std::io::Error::new(std::io::ErrorKind::Other, e)
             })?;

--- a/aw-sync/src/main.rs
+++ b/aw-sync/src/main.rs
@@ -16,10 +16,11 @@ extern crate serde_json;
 use std::path::Path;
 
 use chrono::{DateTime, Utc};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 use aw_client_rust::AwClient;
 
+mod accessmethod;
 mod sync;
 
 const DEFAULT_PORT: &str = "5600";
@@ -27,6 +28,9 @@ const DEFAULT_PORT: &str = "5600";
 #[derive(Parser)]
 #[clap(version = "0.1", author = "Erik Bjäreholt")]
 struct Opts {
+    #[clap(subcommand)]
+    command: Commands,
+
     /// Host of instance to connect to
     #[clap(long, default_value = "127.0.0.1")]
     host: String,
@@ -40,16 +44,26 @@ struct Opts {
     /// If not specified, exit
     #[clap(long)]
     sync_dir: String,
-    /// Date to start syncing from
-    /// If not specified, start from beginning
-    /// NOTE: might be unstable, as count cannot be used to verify integrity of sync.
-    /// Format: YYYY-MM-DD
-    #[clap(long)]
-    start_date: Option<String>,
-    /// Specify buckets to sync
-    /// If not specified, all buckets will be synced
-    #[clap(long)]
-    buckets: Vec<String>,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Clones repos
+    #[clap(arg_required_else_help = true)]
+    Sync {
+        /// Date to start syncing from
+        /// If not specified, start from beginning
+        /// NOTE: might be unstable, as count cannot be used to verify integrity of sync.
+        /// Format: YYYY-MM-DD
+        #[clap(long)]
+        start_date: Option<String>,
+        /// Specify buckets to sync
+        /// If not specified, all buckets will be synced
+        #[clap(long)]
+        buckets: Vec<String>,
+    },
+    /// List buckets and their sync status
+    List {},
 }
 
 fn main() -> std::io::Result<()> {
@@ -74,16 +88,37 @@ fn main() -> std::io::Result<()> {
 
     let client = AwClient::new(opts.host.as_str(), port, "aw-sync-rust");
 
-    let start: Option<DateTime<Utc>> = opts.start_date.map(|date| {
-        chrono::DateTime::parse_from_rfc3339(&date)
-            .unwrap()
-            .with_timezone(&chrono::Utc)
-    });
-    sync::sync_run(sync_directory, client, opts.buckets, start).map_err(|e| {
+    match &opts.command {
+        // Perform two-way sync
+        Commands::Sync {
+            start_date,
+            buckets,
+        } => {
+            let start: Option<DateTime<Utc>> = start_date.as_ref().map(|date| {
+                let date_copy = date.clone();
+                chrono::DateTime::parse_from_rfc3339(&date_copy)
+                    .unwrap()
+                    .with_timezone(&chrono::Utc)
+            });
+
+            sync::sync_run(sync_directory, client, buckets, start).map_err(|e| {
+                println!("Error: {}", e);
+                std::io::Error::new(std::io::ErrorKind::Other, e)
+            })?;
+            info!("Finished successfully, exiting...");
+            Ok(())
+        }
+
+        // List all buckets
+        Commands::List {} => {
+            sync::list_buckets(&client, sync_directory);
+            Ok(())
+        }
+    }
+    .map_err(|e: String| {
         println!("Error: {}", e);
         std::io::Error::new(std::io::ErrorKind::Other, e)
     })?;
-    info!("Finished successfully, exiting...");
 
     // Needed to give the datastores some time to commit before program is shut down.
     // 100ms isn't actually needed, seemed to work fine with as little as 10ms, but I'd rather give

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -135,6 +135,7 @@ fn create_datastore(dspath: &PathBuf) -> Datastore {
     Datastore::new(pathstr, false)
 }
 
+// TODO: Move into tests
 fn setup_test(sync_directory: &Path) -> std::io::Result<Vec<Datastore>> {
     let mut datastores: Vec<Datastore> = Vec::new();
     for n in 0..2 {
@@ -238,7 +239,7 @@ pub fn sync_datastores(
     ds_to: &dyn AccessMethod,
     is_push: bool,
     src_did: Option<&str>,
-    buckets: &Vec<String>,
+    buckets: &[String],
 ) {
     // FIXME: "-synced" should only be appended when synced to the local database, not to the
     // staging area for local buckets.
@@ -258,7 +259,7 @@ pub fn sync_datastores(
         })
         // If buckets vec isn't empty, filter out buckets not in the buckets vec
         .filter(|bucket| {
-            if buckets.len() > 0 {
+            if buckets.is_empty() {
                 buckets.iter().any(|b_id| b_id == &bucket.id)
             } else {
                 true

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -121,7 +121,12 @@ impl AccessMethod for AwClient {
 }
 
 /// Performs a single sync pass
-pub fn sync_run(sync_directory: &Path, client: AwClient) {
+pub fn sync_run(
+    sync_directory: &Path,
+    client: AwClient,
+    buckets: Vec<String>,
+    start: Option<DateTime<Utc>>,
+) -> Result<(), String> {
     fs::create_dir_all(sync_directory).unwrap();
 
     let info = client.get_info().unwrap();
@@ -166,6 +171,8 @@ pub fn sync_run(sync_directory: &Path, client: AwClient) {
     for ds_from in &ds_remotes {
         log_buckets(ds_from);
     }
+
+    Ok(())
 }
 
 /// Returns a list of all remote dbs

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -142,6 +142,8 @@ pub fn sync_run(sync_directory: &Path, client: AwClient) {
 
     let remote_dbfiles = find_remotes_nonlocal(sync_directory, info.device_id.as_str());
     info!("Found remotes: {:?}", remote_dbfiles);
+
+    // TODO: Check for compatible remote db version before opening
     let ds_remotes: Vec<Datastore> = remote_dbfiles.iter().map(create_datastore).collect();
 
     // Pull

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -77,12 +77,18 @@ pub fn sync_run(client: AwClient, sync_spec: &SyncSpec) -> Result<(), String> {
     );
 
     // Close open database connections
-    for ds_from in &ds_remotes {
-        ds_from.close();
-    }
-    ds_localremote.close();
+    //for ds_from in &ds_remotes {
+    //    ds_from.close();
+    //}
+    //ds_localremote.close();
 
-    // Will fail if db connections not closed (as it will open them again)
+    // Dropping also works to close the database connections, weirdly enough.
+    // Probably because once the database is dropped, the thread will stop,
+    // and then the Connection will be dropped, which closes the connection.
+    std::mem::drop(ds_remotes);
+    std::mem::drop(ds_localremote);
+
+    // NOTE: Will fail if db connections not closed (as it will open them again)
     list_buckets(&client, sync_spec.path.as_path());
 
     Ok(())
@@ -163,7 +169,7 @@ fn find_remotes_nonlocal(sync_directory: &Path, device_id: &str) -> Vec<PathBuf>
         .collect()
 }
 
-fn create_datastore(path: &Path) -> Datastore {
+pub fn create_datastore(path: &Path) -> Datastore {
     let pathstr = path.as_os_str().to_str().unwrap();
     Datastore::new(pathstr.to_string(), false)
 }

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -13,7 +13,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use aw_client_rust::AwClient;
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Utc};
 
 use aw_datastore::{Datastore, DatastoreError};
 use aw_models::{Bucket, Event};
@@ -157,61 +157,6 @@ fn find_remotes_nonlocal(sync_directory: &Path, device_id: &str) -> Vec<PathBuf>
 fn create_datastore(path: &Path) -> Datastore {
     let pathstr = path.as_os_str().to_str().unwrap();
     Datastore::new(pathstr.to_string(), false)
-}
-
-// TODO: Move into tests
-fn setup_test(sync_directory: &Path) -> std::io::Result<Vec<Datastore>> {
-    let mut datastores: Vec<Datastore> = Vec::new();
-    for n in 0..2 {
-        let dspath = sync_directory.join(format!("test-remote-{}.db", n));
-        let ds_ = create_datastore(&dspath);
-        let ds = &ds_ as &dyn AccessMethod;
-
-        // Create a bucket
-        // NOTE: Created with duplicate name to make sure it still works under such conditions
-        let bucket_jsonstr = format!(
-            r#"{{
-                "id": "bucket",
-                "type": "test",
-                "hostname": "device-{}",
-                "client": "test"
-            }}"#,
-            n
-        );
-        let bucket: Bucket = serde_json::from_str(&bucket_jsonstr)?;
-        match ds.create_bucket(&bucket) {
-            Ok(()) => (),
-            Err(e) => match e {
-                DatastoreError::BucketAlreadyExists(_) => {
-                    debug!("bucket already exists, skipping");
-                }
-                e => panic!("woops! {:?}", e),
-            },
-        };
-
-        // Insert some testing events into the bucket
-        let events: Vec<Event> = (0..3)
-            .map(|i| {
-                let timestamp: DateTime<Utc> = Utc::now() + Duration::milliseconds(i * 10);
-                let event_jsonstr = format!(
-                    r#"{{
-                "timestamp": "{}",
-                "duration": 0,
-                "data": {{"test": {} }}
-            }}"#,
-                    timestamp.to_rfc3339(),
-                    i
-                );
-                serde_json::from_str(&event_jsonstr).unwrap()
-            })
-            .collect::<Vec<Event>>();
-
-        ds.insert_events(bucket.id.as_str(), events).unwrap();
-        //let new_eventcount = ds.get_event_count(bucket.id.as_str(), None, None).unwrap();
-        //info!("Eventcount: {:?} ({} new)", new_eventcount, events.len());
-        datastores.push(ds_);
-    }
-    Ok(datastores)
 }
 
 /// Returns the sync-destination bucket for a given bucket, creates it if it doesn't exist.

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -9,124 +9,19 @@ extern crate chrono;
 extern crate reqwest;
 extern crate serde_json;
 
-use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use aw_client_rust::AwClient;
 use chrono::{DateTime, Duration, Utc};
-use reqwest::StatusCode;
 
 use aw_datastore::{Datastore, DatastoreError};
 use aw_models::{Bucket, Event};
 
-// This trait should be implemented by both AwClient and Datastore, unifying them under a single API
-pub trait AccessMethod: std::fmt::Debug {
-    fn get_buckets(&self) -> Result<HashMap<String, Bucket>, String>;
-    fn get_bucket(&self, bucket_id: &str) -> Result<Bucket, DatastoreError>;
-    fn create_bucket(&self, bucket: &Bucket) -> Result<(), DatastoreError>;
-    fn get_events(
-        &self,
-        bucket_id: &str,
-        start: Option<DateTime<Utc>>,
-        end: Option<DateTime<Utc>>,
-        limit: Option<u64>,
-    ) -> Result<Vec<Event>, String>;
-    fn insert_events(&self, bucket_id: &str, events: Vec<Event>) -> Result<Vec<Event>, String>;
-    fn get_event_count(&self, bucket_id: &str) -> Result<i64, String>;
-    fn heartbeat(&self, bucket_id: &str, event: Event, duration: f64) -> Result<(), String>;
-}
+use crate::accessmethod::AccessMethod;
 
-impl AccessMethod for Datastore {
-    fn get_buckets(&self) -> Result<HashMap<String, Bucket>, String> {
-        Ok(self.get_buckets().unwrap())
-    }
-    fn get_bucket(&self, bucket_id: &str) -> Result<Bucket, DatastoreError> {
-        self.get_bucket(bucket_id)
-    }
-    fn create_bucket(&self, bucket: &Bucket) -> Result<(), DatastoreError> {
-        self.create_bucket(bucket)?;
-        self.force_commit().unwrap();
-        Ok(())
-    }
-    fn get_events(
-        &self,
-        bucket_id: &str,
-        start: Option<DateTime<Utc>>,
-        end: Option<DateTime<Utc>>,
-        limit: Option<u64>,
-    ) -> Result<Vec<Event>, String> {
-        Ok(self.get_events(bucket_id, start, end, limit).unwrap())
-    }
-    fn heartbeat(&self, bucket_id: &str, event: Event, duration: f64) -> Result<(), String> {
-        self.heartbeat(bucket_id, event, duration).unwrap();
-        self.force_commit().unwrap();
-        Ok(())
-    }
-    fn insert_events(&self, bucket_id: &str, events: Vec<Event>) -> Result<Vec<Event>, String> {
-        let res = self.insert_events(bucket_id, &events[..]).unwrap();
-        self.force_commit().unwrap();
-        Ok(res)
-    }
-    fn get_event_count(&self, bucket_id: &str) -> Result<i64, String> {
-        Ok(self.get_event_count(bucket_id, None, None).unwrap())
-    }
-}
-
-impl AccessMethod for AwClient {
-    fn get_buckets(&self) -> Result<HashMap<String, Bucket>, String> {
-        Ok(self.get_buckets().unwrap())
-    }
-    fn get_bucket(&self, bucket_id: &str) -> Result<Bucket, DatastoreError> {
-        let bucket = self.get_bucket(bucket_id);
-        match bucket {
-            Ok(bucket) => Ok(bucket),
-            Err(e) => {
-                warn!("{:?}", e);
-                let code = e.status().unwrap();
-                if code == StatusCode::NOT_FOUND {
-                    Err(DatastoreError::NoSuchBucket(bucket_id.into()))
-                } else {
-                    panic!("Unexpected error");
-                }
-            }
-        }
-    }
-    fn get_events(
-        &self,
-        bucket_id: &str,
-        start: Option<DateTime<Utc>>,
-        end: Option<DateTime<Utc>>,
-        limit: Option<u64>,
-    ) -> Result<Vec<Event>, String> {
-        Ok(self.get_events(bucket_id, start, end, limit).unwrap())
-    }
-    fn insert_events(&self, _bucket_id: &str, _events: Vec<Event>) -> Result<Vec<Event>, String> {
-        //Ok(self.insert_events(bucket_id, &events[..]).unwrap())
-        Err("Not implemented".to_string())
-    }
-    fn get_event_count(&self, bucket_id: &str) -> Result<i64, String> {
-        Ok(self.get_event_count(bucket_id).unwrap())
-    }
-    fn create_bucket(&self, bucket: &Bucket) -> Result<(), DatastoreError> {
-        self.create_bucket(bucket.id.as_str(), bucket._type.as_str())
-            .unwrap();
-        Ok(())
-        //Err(DatastoreError::InternalError("Not implemented".to_string()))
-    }
-    fn heartbeat(&self, bucket_id: &str, event: Event, duration: f64) -> Result<(), String> {
-        self.heartbeat(bucket_id, &event, duration)
-            .map_err(|e| format!("{:?}", e))
-    }
-}
-
-/// Performs a single sync pass
-pub fn sync_run(
-    sync_directory: &Path,
-    client: AwClient,
-    buckets: Vec<String>,
-    start: Option<DateTime<Utc>>,
-) -> Result<(), String> {
+fn setup_local_remote(client: &AwClient, sync_directory: &Path) -> Result<Datastore, String> {
+    // FIXME: Don't run twice if already exists
     fs::create_dir_all(sync_directory).unwrap();
 
     let info = client.get_info().unwrap();
@@ -142,9 +37,22 @@ pub fn sync_run(
     let ds_localremote = Datastore::new(dbfile, false);
     info!("Set up remote for local device");
 
+    Ok(ds_localremote)
+}
+
+/// Performs a single sync pass
+pub fn sync_run(
+    sync_directory: &Path,
+    client: AwClient,
+    buckets: &Vec<String>,
+    start: Option<DateTime<Utc>>,
+) -> Result<(), String> {
+    let ds_localremote = setup_local_remote(&client, sync_directory)?;
+
     //let ds_remotes = setup_test(sync_directory).unwrap();
     //info!("Set up remotes for testing");
 
+    let info = client.get_info().unwrap();
     let remote_dbfiles = find_remotes_nonlocal(sync_directory, info.device_id.as_str());
     info!("Found remotes: {:?}", remote_dbfiles);
 
@@ -154,7 +62,7 @@ pub fn sync_run(
     // Pull
     info!("Pulling...");
     for ds_from in &ds_remotes {
-        sync_datastores(ds_from, &client, false, None);
+        sync_datastores(ds_from, &client, false, None, &buckets);
     }
 
     // Push local server buckets to sync folder
@@ -164,15 +72,29 @@ pub fn sync_run(
         &ds_localremote,
         true,
         Some(info.device_id.as_str()),
+        &buckets,
     );
 
-    log_buckets(&client);
+    list_buckets(&client, sync_directory);
+
+    Ok(())
+}
+
+pub fn list_buckets(client: &AwClient, sync_directory: &Path) {
+    let ds_localremote = setup_local_remote(client, sync_directory).unwrap();
+
+    let info = client.get_info().unwrap();
+    let remote_dbfiles = find_remotes_nonlocal(sync_directory, info.device_id.as_str());
+    info!("Found remotes: {:?}", remote_dbfiles);
+
+    // TODO: Check for compatible remote db version before opening
+    let ds_remotes: Vec<Datastore> = remote_dbfiles.iter().map(create_datastore).collect();
+
+    log_buckets(client);
     log_buckets(&ds_localremote);
     for ds_from in &ds_remotes {
         log_buckets(ds_from);
     }
-
-    Ok(())
 }
 
 /// Returns a list of all remote dbs
@@ -182,7 +104,7 @@ fn find_remotes(sync_directory: &Path) -> std::io::Result<Vec<PathBuf>> {
         .map(|res| res.ok().unwrap().path())
         .filter(|p| p.is_dir())
         .flat_map(|d| {
-            println!("{}", d.to_str().unwrap());
+            //println!("{}", d.to_str().unwrap());
             fs::read_dir(d).unwrap()
         })
         .map(|res| res.ok().unwrap().path())
@@ -316,6 +238,7 @@ pub fn sync_datastores(
     ds_to: &dyn AccessMethod,
     is_push: bool,
     src_did: Option<&str>,
+    buckets: &Vec<String>,
 ) {
     // FIXME: "-synced" should only be appended when synced to the local database, not to the
     // staging area for local buckets.
@@ -333,6 +256,8 @@ pub fn sync_datastores(
             }
             tup.1.clone()
         })
+        // Filter out buckets not in the buckets vec
+        .filter(|bucket| buckets.iter().any(|b_id| b_id == &bucket.id))
         .collect();
 
     // Sync buckets in order of most recently updated

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -62,7 +62,7 @@ pub fn sync_run(
     // Pull
     info!("Pulling...");
     for ds_from in &ds_remotes {
-        sync_datastores(ds_from, &client, false, None, &buckets);
+        sync_datastores(ds_from, &client, false, None, buckets);
     }
 
     // Push local server buckets to sync folder
@@ -72,7 +72,7 @@ pub fn sync_run(
         &ds_localremote,
         true,
         Some(info.device_id.as_str()),
-        &buckets,
+        buckets,
     );
 
     list_buckets(&client, sync_directory);
@@ -256,8 +256,14 @@ pub fn sync_datastores(
             }
             tup.1.clone()
         })
-        // Filter out buckets not in the buckets vec
-        .filter(|bucket| buckets.iter().any(|b_id| b_id == &bucket.id))
+        // If buckets vec isn't empty, filter out buckets not in the buckets vec
+        .filter(|bucket| {
+            if buckets.len() > 0 {
+                buckets.iter().any(|b_id| b_id == &bucket.id)
+            } else {
+                true
+            }
+        })
         .collect();
 
     // Sync buckets in order of most recently updated

--- a/aw-sync/test-import-sync.sh
+++ b/aw-sync/test-import-sync.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# get script path
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+pushd $SCRIPTPATH
+
+# port used for testing instance
+PORT=5667
+
+# if server already running on port 5667, don't start again
+if [ "$(lsof -i:$PORT -sTCP:LISTEN -t)" ]; then
+    echo "ActivityWatch server already running on port $PORT, using that."
+else
+    # Set up an isolated ActivityWatch instance
+    ./test-server.sh $PORT &
+fi
+
+
+sleep 1;
+SYNCROOTDIR="$HOME/ActivityWatchSync"
+
+# For each host in the sync directory, pull the data from each database file using aw-sync
+for host in $(ls $SYNCROOTDIR); do
+    SYNCDIR="$SYNCROOTDIR/$host"
+    for db in $(ls $SYNCDIR/*/*.db); do
+        AWSYNCPARAMS="--port $PORT --sync-dir $SYNCDIR"
+        BUCKETS="aw-watcher-window_$host,aw-watcher-afk_$host"
+
+        echo "Syncing $db to $host"
+        cargo run --bin aw-sync -- $AWSYNCPARAMS sync --mode pull --buckets $BUCKETS
+    done
+done
+
+# kill aw-server-rust
+#kill %1
+fg

--- a/aw-sync/test-server.sh
+++ b/aw-sync/test-server.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# port and db used for testing instance
+
+# If port already set, use that, otherwise, use 5667
+PORT=${PORT:-5667}
+
+DBPATH=/tmp/aw-server-rust-sync-testing/
+mkdir -p $DBPATH
+
+# Set up an isolated ActivityWatch instance
+pushd ..
+cargo run --bin aw-server -- --testing --port $PORT --dbpath $DBPATH/data.db --no-legacy-import

--- a/aw-sync/test-sync.sh
+++ b/aw-sync/test-sync.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Helper script meant to be used to test aw-sync
+# Example of a single-entry for cronjobs and the like
+
+HOSTNAME="Teklas-Air.localdomain"
+SYNCDIR="~/ActivityWatchSync/tekla-air-m1"
+AWSYNCPARAMS="--port 5601 --sync-dir $SYNCDIR"
+
+# TODO: Fix supplying multiple buckets in a single command
+# NOTE: Only sync window and AFK buckets, for now
+cargo run --bin aw-sync -- $AWSYNCPARAMS sync --buckets aw-watcher-window_$HOSTNAME
+cargo run --bin aw-sync -- $AWSYNCPARAMS sync --buckets aw-watcher-afk_$HOSTNAME

--- a/aw-sync/test-sync.sh
+++ b/aw-sync/test-sync.sh
@@ -15,4 +15,4 @@ AWSYNCPARAMS="--port $PORT --sync-dir $SYNCDIR"
 
 # TODO: Fix supplying multiple buckets in a single command
 # NOTE: Only sync window and AFK buckets, for now
-cargo run --bin aw-sync -- $AWSYNCPARAMS sync --buckets aw-watcher-window_$HOSTNAME,aw-watcher-afk_$HOSTNAME
+cargo run --bin aw-sync -- $AWSYNCPARAMS sync --mode push --buckets aw-watcher-window_$HOSTNAME,aw-watcher-afk_$HOSTNAME

--- a/aw-sync/test-sync.sh
+++ b/aw-sync/test-sync.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
-
 # Helper script meant to be used to test aw-sync
 # Example of a single-entry for cronjobs and the like
 
-HOSTNAME="Teklas-Air.localdomain"
-SYNCDIR="~/ActivityWatchSync/tekla-air-m1"
-AWSYNCPARAMS="--port 5601 --sync-dir $SYNCDIR"
+HOSTNAME=$(hostnamectl --static)
+# TODO: Fetch in a cross-platform way (from aw-client command output?)
+AWSERVERCONF=~/.config/activitywatch/aw-server/aw-server.toml
+
+# trim everything in file AWSERVERCONF before '[server-testing]' section
+# grep for the aw-server port in aw-server.toml
+PORT=$(sed '/\[server-testing\]/,/\[.*\]/{//!d}' $AWSERVERCONF | grep -oP 'port = "\K[0-9]+')
+
+SYNCDIR="$HOME/ActivityWatchSync/$HOSTNAME"
+AWSYNCPARAMS="--port $PORT --sync-dir $SYNCDIR"
 
 # TODO: Fix supplying multiple buckets in a single command
 # NOTE: Only sync window and AFK buckets, for now
-cargo run --bin aw-sync -- $AWSYNCPARAMS sync --buckets aw-watcher-window_$HOSTNAME
-cargo run --bin aw-sync -- $AWSYNCPARAMS sync --buckets aw-watcher-afk_$HOSTNAME
+cargo run --bin aw-sync -- $AWSYNCPARAMS sync --buckets aw-watcher-window_$HOSTNAME,aw-watcher-afk_$HOSTNAME

--- a/aw-sync/tests/sync.rs
+++ b/aw-sync/tests/sync.rs
@@ -211,7 +211,7 @@ mod sync_tests {
         check_synced_buckets_equal_to_src(&all_buckets_map);
     }
 
-    // TODO: Move into tests
+    // TODO: Find a way to reuse this (previously used in an integration test)
     fn setup_test(sync_directory: &Path) -> std::io::Result<Vec<Datastore>> {
         let mut datastores: Vec<Datastore> = Vec::new();
         for n in 0..2 {

--- a/aw-sync/tests/sync.rs
+++ b/aw-sync/tests/sync.rs
@@ -101,7 +101,7 @@ mod sync_tests {
         let state = init_teststate();
         create_bucket(&state.ds_src, 0);
 
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None);
+        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &vec![]);
 
         let buckets_src: HashMap<String, Bucket> = state.ds_src.get_buckets().unwrap();
         let buckets_dest: HashMap<String, Bucket> = state.ds_dest.get_buckets().unwrap();
@@ -136,7 +136,7 @@ mod sync_tests {
             .heartbeat(bucket_id.as_str(), create_event("1"), 1.0)
             .unwrap();
 
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None);
+        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &vec![]);
 
         let all_datastores: Vec<&Datastore> =
             [&state.ds_src, &state.ds_dest].iter().cloned().collect();
@@ -150,7 +150,7 @@ mod sync_tests {
             .ds_src
             .heartbeat(bucket_id.as_str(), create_event("1"), 1.0)
             .unwrap();
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None);
+        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &vec![]);
 
         // Check again that new events were indeed synced
         check_synced_buckets_equal_to_src(&all_buckets_map);
@@ -163,7 +163,7 @@ mod sync_tests {
         let bucket_id = create_bucket(&state.ds_src, 0);
         create_events(&state.ds_src, bucket_id.as_str(), 10);
 
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None);
+        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &vec![]);
 
         let all_datastores: Vec<&Datastore> =
             [&state.ds_src, &state.ds_dest].iter().cloned().collect();
@@ -174,7 +174,7 @@ mod sync_tests {
 
         // Add some more events
         create_events(&state.ds_src, bucket_id.as_str(), 10);
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None);
+        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &vec![]);
 
         // Check again that new events were indeed synced
         check_synced_buckets_equal_to_src(&all_buckets_map);

--- a/aw-sync/tests/sync.rs
+++ b/aw-sync/tests/sync.rs
@@ -101,7 +101,7 @@ mod sync_tests {
         let state = init_teststate();
         create_bucket(&state.ds_src, 0);
 
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &vec![]);
+        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &[]);
 
         let buckets_src: HashMap<String, Bucket> = state.ds_src.get_buckets().unwrap();
         let buckets_dest: HashMap<String, Bucket> = state.ds_dest.get_buckets().unwrap();
@@ -136,7 +136,7 @@ mod sync_tests {
             .heartbeat(bucket_id.as_str(), create_event("1"), 1.0)
             .unwrap();
 
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &vec![]);
+        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &[]);
 
         let all_datastores: Vec<&Datastore> =
             [&state.ds_src, &state.ds_dest].iter().cloned().collect();
@@ -150,7 +150,7 @@ mod sync_tests {
             .ds_src
             .heartbeat(bucket_id.as_str(), create_event("1"), 1.0)
             .unwrap();
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &vec![]);
+        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &[]);
 
         // Check again that new events were indeed synced
         check_synced_buckets_equal_to_src(&all_buckets_map);
@@ -163,7 +163,7 @@ mod sync_tests {
         let bucket_id = create_bucket(&state.ds_src, 0);
         create_events(&state.ds_src, bucket_id.as_str(), 10);
 
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &vec![]);
+        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &[]);
 
         let all_datastores: Vec<&Datastore> =
             [&state.ds_src, &state.ds_dest].iter().cloned().collect();
@@ -174,7 +174,7 @@ mod sync_tests {
 
         // Add some more events
         create_events(&state.ds_src, bucket_id.as_str(), 10);
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &vec![]);
+        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &[]);
 
         // Check again that new events were indeed synced
         check_synced_buckets_equal_to_src(&all_buckets_map);

--- a/aw-sync/tests/sync.rs
+++ b/aw-sync/tests/sync.rs
@@ -4,13 +4,14 @@ extern crate aw_sync;
 
 #[cfg(test)]
 mod sync_tests {
-    use chrono::{DateTime, Utc};
     use std::collections::HashMap;
+    use std::path::Path;
+
+    use chrono::{DateTime, Duration, Utc};
 
     use aw_datastore::{Datastore, DatastoreError};
     use aw_models::{Bucket, Event};
-    use aw_sync;
-    use aw_sync::SyncSpec;
+    use aw_sync::{create_datastore, AccessMethod, SyncSpec};
 
     struct TestState {
         ds_src: Datastore,

--- a/aw-sync/tests/sync.rs
+++ b/aw-sync/tests/sync.rs
@@ -10,6 +10,7 @@ mod sync_tests {
     use aw_datastore::{Datastore, DatastoreError};
     use aw_models::{Bucket, Event};
     use aw_sync;
+    use aw_sync::SyncSpec;
 
     struct TestState {
         ds_src: Datastore,
@@ -101,7 +102,13 @@ mod sync_tests {
         let state = init_teststate();
         create_bucket(&state.ds_src, 0);
 
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &[]);
+        aw_sync::sync_datastores(
+            &state.ds_src,
+            &state.ds_dest,
+            false,
+            None,
+            &SyncSpec::default(),
+        );
 
         let buckets_src: HashMap<String, Bucket> = state.ds_src.get_buckets().unwrap();
         let buckets_dest: HashMap<String, Bucket> = state.ds_dest.get_buckets().unwrap();
@@ -136,7 +143,13 @@ mod sync_tests {
             .heartbeat(bucket_id.as_str(), create_event("1"), 1.0)
             .unwrap();
 
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &[]);
+        aw_sync::sync_datastores(
+            &state.ds_src,
+            &state.ds_dest,
+            false,
+            None,
+            &SyncSpec::default(),
+        );
 
         let all_datastores: Vec<&Datastore> =
             [&state.ds_src, &state.ds_dest].iter().cloned().collect();
@@ -150,7 +163,13 @@ mod sync_tests {
             .ds_src
             .heartbeat(bucket_id.as_str(), create_event("1"), 1.0)
             .unwrap();
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &[]);
+        aw_sync::sync_datastores(
+            &state.ds_src,
+            &state.ds_dest,
+            false,
+            None,
+            &SyncSpec::default(),
+        );
 
         // Check again that new events were indeed synced
         check_synced_buckets_equal_to_src(&all_buckets_map);
@@ -163,7 +182,13 @@ mod sync_tests {
         let bucket_id = create_bucket(&state.ds_src, 0);
         create_events(&state.ds_src, bucket_id.as_str(), 10);
 
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &[]);
+        aw_sync::sync_datastores(
+            &state.ds_src,
+            &state.ds_dest,
+            false,
+            None,
+            &SyncSpec::default(),
+        );
 
         let all_datastores: Vec<&Datastore> =
             [&state.ds_src, &state.ds_dest].iter().cloned().collect();
@@ -174,7 +199,13 @@ mod sync_tests {
 
         // Add some more events
         create_events(&state.ds_src, bucket_id.as_str(), 10);
-        aw_sync::sync_datastores(&state.ds_src, &state.ds_dest, false, None, &[]);
+        aw_sync::sync_datastores(
+            &state.ds_src,
+            &state.ds_dest,
+            false,
+            None,
+            &SyncSpec::default(),
+        );
 
         // Check again that new events were indeed synced
         check_synced_buckets_equal_to_src(&all_buckets_map);


### PR DESCRIPTION
- [x] Add a proper CLI
   - Able to set: sync folder, pick buckets, since some date, which instance to connect to as the local one (incl `--testing`), and which mode (pull, push, both).
- [x] Improved logging output
- [x] Actually tested to work in prod-like environment
   - See the added `test-*.sh` scripts
- [ ] Document setting up a test environment
- [x] Better performance on many events
 - [ ] Add "verify" command to verify bucket contents match (support optional --since parameter for partial verification)