### PR TITLE
ci: switched to tarpaulin for code coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build on ${{ matrix.os }}
+    name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -48,7 +48,7 @@ jobs:
           target/*/aw-server.exe
 
   build-android:
-    name: Build for Android
+    name: Android
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -86,7 +86,7 @@ jobs:
   # Works better than grcov, but not as many fancy features (no branch coverage, no LLVM)
   # See: https://shift.click/blog/github-actions-rust/#code-coverage
   build-coverage-tarpaulin:
-    name: Generate code coverage
+    name: Code coverage
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -142,22 +142,3 @@ jobs:
   #      make coverage-lcov COVERAGE_CACHE=1
   #  - name: Upload coverage files
   #    run: bash <(curl -s https://codecov.io/bash) -f target/debug/lcov.info;
-
-  lint:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Rust nightly
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly
-        components: clippy, rustfmt
-        override: true
-    - name: Check formatting
-      if: always()
-      run: cargo fmt -- --check
-    - name: Run clippy  # Doesn't fail build
-      if: always()
-      run: cargo clippy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2022-03-14  # https://github.com/rust-lang/rust/issues/94998
+        toolchain: nightly
         override: true
     - name: Cache cargo build
       uses: actions/cache@v1
@@ -47,41 +47,6 @@ jobs:
           target/*/aw-server
           target/*/aw-server.exe
 
-  build-coverage:
-    name: Build with coverage
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Rust nightly
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: nightly-2022-03-14  # https://github.com/rust-lang/rust/issues/94998
-        override: true
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      env:
-        cache-name: cargo-build-target-coverage
-      with:
-        path: target
-        key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.cache-name }}-
-    - name:  Install llvm-tools
-      run: |
-        rustup component add llvm-tools-preview
-    - name: Download grcov
-      run: |
-        curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-x86_64-unknown-linux-gnu.tar.bz2  | tar jxf -
-    - name: Run tests with coverage
-      run: |
-        # Add cwd to path to find grcov
-        export PATH=$PATH:.
-        make coverage-lcov COVERAGE_CACHE=1
-    - name: Upload coverage files
-      run: bash <(curl -s https://codecov.io/bash) -f target/debug/lcov.info;
-
   build-android:
     name: Build for Android
     runs-on: ubuntu-latest
@@ -91,7 +56,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly-2022-03-14  # https://github.com/rust-lang/rust/issues/94998
+        toolchain: nightly
         override: true
     - name: Cache cargo build
       uses: actions/cache@v1
@@ -116,6 +81,67 @@ jobs:
         name: binaries-android
         path: |
           target/*/*/libaw_server.so
+
+  # Code coverage using tarpaulin
+  # Works better than grcov, but not as many fancy features (no branch coverage, no LLVM)
+  # See: https://shift.click/blog/github-actions-rust/#code-coverage
+  build-coverage-tarpaulin:
+    name: Generate code coverage
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Rust nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        override: true
+
+    # Note: If you need to combine the coverage info of multiple
+    # feature sets, you need a `.tarpaulin.toml` config file, see
+    # the link above for those docs.
+    - uses: actions-rs/tarpaulin@v0.1
+
+    # Note: closed-source code needs to provide a token,
+    # but open source code does not.
+    - name: Upload to codecov.io
+      uses: codecov/codecov-action@v1
+
+  # Code coverage using grcov
+  #build-coverage-grcov:
+  #  name: Build with coverage
+  #  runs-on: ubuntu-latest
+
+  #  steps:
+  #  - uses: actions/checkout@v2
+  #  - name: Set up Rust nightly
+  #    uses: actions-rs/toolchain@v1
+  #    with:
+  #      profile: minimal
+  #      toolchain: nightly
+  #      override: true
+  #  - name: Cache cargo build
+  #    uses: actions/cache@v1
+  #    env:
+  #      cache-name: cargo-build-target-coverage
+  #    with:
+  #      path: target
+  #      key: ${{ runner.os }}-${{ env.cache-name }}-${{ hashFiles('**/Cargo.lock') }}
+  #      restore-keys: |
+  #        ${{ runner.os }}-${{ env.cache-name }}-
+  #  - name:  Install llvm-tools
+  #    run: |
+  #      rustup component add llvm-tools-preview
+  #  - name: Download grcov
+  #    run: |
+  #      curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-x86_64-unknown-linux-gnu.tar.bz2  | tar jxf -
+  #  - name: Run tests with coverage
+  #    run: |
+  #      # Add cwd to path to find grcov
+  #      export PATH=$PATH:.
+  #      make coverage-lcov COVERAGE_CACHE=1
+  #  - name: Upload coverage files
+  #    run: bash <(curl -s https://codecov.io/bash) -f target/debug/lcov.info;
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,38 @@
+name: Lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Rust nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        components: rustfmt
+        override: true
+    - name: Check formatting
+      run: cargo fmt -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Rust nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        components: clippy
+        override: true
+    - name: Run clippy
+      run: cargo clippy


### PR DESCRIPTION
As described in https://github.com/ActivityWatch/aw-server-rust/pull/270#issuecomment-1074933764