### PR TITLE
feat: add custom visualization support (custom_static)

### DIFF
--- a/aw-server/src/config.rs
+++ b/aw-server/src/config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::dirs;
 
-/* Far from an optimal way to solve it, but works and is simple */
+// Far from an optimal way to solve it, but works and is simple
 static mut TESTING: bool = true;
 pub fn set_testing(testing: bool) {
     unsafe {
@@ -22,12 +22,20 @@ pub fn is_testing() -> bool {
 pub struct AWConfig {
     #[serde(default = "default_address")]
     pub address: String,
+
     #[serde(default = "default_port")]
     pub port: u16,
+
     #[serde(skip, default = "default_testing")]
     pub testing: bool, // This is not written to the config file (serde(skip))
+
     #[serde(default = "default_cors")]
     pub cors: Vec<String>,
+
+    // A mapping of watcher names to paths where the
+    // custom visualizations are located.
+    #[serde(default = "default_custom_static")]
+    pub custom_static: std::collections::HashMap<String, String>,
 }
 
 impl Default for AWConfig {
@@ -37,6 +45,7 @@ impl Default for AWConfig {
             port: default_port(),
             testing: default_testing(),
             cors: default_cors(),
+            custom_static: default_custom_static(),
         }
     }
 }
@@ -81,6 +90,10 @@ fn default_port() -> u16 {
     } else {
         5600
     }
+}
+
+fn default_custom_static() -> std::collections::HashMap<String, String> {
+    std::collections::HashMap::new()
 }
 
 pub fn create_config(testing: bool) -> AWConfig {

--- a/aw-server/src/endpoints/mod.rs
+++ b/aw-server/src/endpoints/mod.rs
@@ -5,8 +5,10 @@ use gethostname::gethostname;
 use rocket::fs::NamedFile;
 use rocket::serde::json::Json;
 use rocket::State;
+use rocket::fs::FileServer;
 
 use crate::config::AWConfig;
+use crate::dirs;
 
 use aw_datastore::Datastore;
 use aw_models::Info;
@@ -92,6 +94,8 @@ pub fn build_rocket(server_state: ServerState, config: AWConfig) -> rocket::Rock
     );
     let cors = cors::cors(&config);
     let hostcheck = hostcheck::HostCheck::new(&config);
+    let mut visualizations_path = dirs::get_data_dir().unwrap();
+    visualizations_path.push("visualizations");
     rocket::custom(config.to_rocket_config())
         .attach(cors.clone())
         .attach(hostcheck)
@@ -142,4 +146,5 @@ pub fn build_rocket(server_state: ServerState, config: AWConfig) -> rocket::Rock
             ],
         )
         .mount("/", rocket_cors::catch_all_options_routes())
+        .mount("/pages", FileServer::from(visualizations_path))
 }

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -39,6 +39,10 @@ struct Opts {
     #[clap(long)]
     webpath: Option<String>,
 
+    /// Mapping of custom static paths to serve, in the format: watcher1=/path,watcher2=/path2
+    #[clap(long)]
+    custom_static: Option<String>,
+
     /// Device ID override
     #[clap(long)]
     device_id: Option<String>,
@@ -73,6 +77,29 @@ async fn main() -> Result<(), rocket::Error> {
     // set port if overridden
     if let Some(port) = opts.port {
         config.port = port.parse().unwrap();
+    }
+
+    // set custom_static if overridden, transform into map
+    if let Some(custom_static_str) = opts.custom_static {
+        let custom_static_map: std::collections::HashMap<String, String> = custom_static_str
+            .split(',')
+            .map(|s| {
+                let mut split = s.split('=');
+                let key = split.next().unwrap().to_string();
+                let value = split.next().unwrap().to_string();
+                (key, value)
+            })
+            .collect();
+        config.custom_static.extend(custom_static_map);
+
+        // validate paths, log error if invalid
+        // remove invalid paths
+        for (name, path) in config.custom_static.clone().iter() {
+            if !std::path::Path::new(path).exists() {
+                error!("custom_static path for {} does not exist ({})", name, path);
+                config.custom_static.remove(name);
+            }
+        }
     }
 
     // Set db path if overridden


### PR DESCRIPTION
I struggled a bit with this since it is my first time with Rust but here it is. I used the FileServer from Rocket because that is the easiest way I found to get custom HTML per watcher.

How to use:
Create a `visualizations` folder in your [data](https://docs.activitywatch.net/en/latest/directories.html#data) folder. Then create a folder for your custom watcher and put your index.html here. Example: `/home/USER/.local/share/activitywatch/aw-server-rust/visualizations/aw-watcher-test/index.html`
You can also load JavaScript from other files, just put them in the same directory.

I tested it with my custom watcher and it works with [custom visualization support](https://github.com/ActivityWatch/aw-server/pull/83) of aw-server web-ui (and so aw-server-rust).