### PR TITLE
Allow ActivityWatch to Ignoring / Filtering

### DIFF
--- a/aw-datastore/src/lib.rs
+++ b/aw-datastore/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(option_result_contains)]
 #[macro_use]
 extern crate log;
 


### PR DESCRIPTION
@ErikBjare @johan-bjareholt - Actually when it came to implementing it -- several things changed from my initial idea that I proposed in https://github.com/ActivityWatch/activitywatch/issues/1

1. I ended up using the brand new KeyValue table in 0.12.0,  So basically in the keyvalue table you can add a new key called `IGNORE_FILTERS` with the json value of: `{"APPS": ["app1", "app2", ...], "TITLES": ["title1", "title2", ...]}`

2. The DataStore module on startup loads this JSON key, parses it into two vectors that it then uses during inserts and replace functions on the event table.   If any of the values you put into the `TITLES` key sub-string matches the `Event.title` it skips adding it to the database.   Ditto with the Event.app against the APPS vector.    This is a substring match so if you put "BRAV" in the APPS then it will filter out any app that contains `BRAV` anywhere in the app name.  (i.e. `BRAVE`, `BRAVO`, `ABRAVING`, etc...

At this point I DO NOT have any GUI to add this value, you just use SQLite (or perhaps a POST to `/` which acts like a KeyValue "set")  but at this point the process works.   