### PR TITLE
Extra debug logging when in testing mode

### DIFF
--- a/aw-server/src/config.rs
+++ b/aw-server/src/config.rs
@@ -3,6 +3,7 @@ use std::io::{Read, Write};
 
 use rocket::config::Config;
 use rocket::data::{Limits, ToByteUnit};
+use rocket::log::LogLevel;
 use serde::{Deserialize, Serialize};
 
 use crate::dirs;
@@ -43,10 +44,12 @@ impl Default for AWConfig {
 
 impl AWConfig {
     pub fn to_rocket_config(&self) -> rocket::Config {
-        let mut config = if self.testing {
-            Config::release_default()
+        let mut config;
+        if self.testing {
+            config = Config::debug_default();
+            config.log_level = LogLevel::Debug;
         } else {
-            Config::debug_default()
+            config = Config::release_default()
         };
 
         // Needed for bucket imports

--- a/aw-server/src/logging.rs
+++ b/aw-server/src/logging.rs
@@ -44,65 +44,43 @@ pub fn setup_logger(testing: bool) -> Result<(), fern::InitError> {
         _ => default_log_level,
     };
 
-    match log_level {
-        log::LevelFilter::Debug | log::LevelFilter::Trace => fern::Dispatch::new()
-            // Set some Rocket messages to debug level
-            .level(log_level)
-            .format(move |out, message, record| {
-                out.finish(format_args!(
-                    "[{}][{}][{}]: {}",
-                    chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
-                    colors.color(record.level()),
-                    record.target(),
-                    message,
-                ))
-            })
-            // Color and higher log levels to stdout
-            .chain(fern::Dispatch::new().chain(std::io::stdout()))
-            // No color and lower log levels to logfile
-            .chain(
-                fern::Dispatch::new()
-                    .format(|out, message, _record| {
-                        out.finish(format_args!(
-                            // TODO: Strip color info
-                            "{}",
-                            message,
-                        ))
-                    })
-                    .chain(fern::log_file(logfile_path)?),
-            )
-            .apply()?,
-        _ => fern::Dispatch::new()
-            // Set some Rocket messages to debug level
-            .level(log_level)
+    let mut dispatch = fern::Dispatch::new().level(log_level);
+    // Set some Rocket messages to debug level
+
+    let is_debug = matches!(log_level, log::LevelFilter::Trace | log::LevelFilter::Debug);
+    if is_debug {
+        dispatch = dispatch
             .level_for("rocket", log::LevelFilter::Warn)
             .level_for("_", log::LevelFilter::Warn) // Rocket requests
-            .level_for("launch_", log::LevelFilter::Warn) // Rocket config info
-            .format(move |out, message, record| {
-                out.finish(format_args!(
-                    "[{}][{}][{}]: {}",
-                    chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
-                    colors.color(record.level()),
-                    record.target(),
-                    message,
-                ))
-            })
-            // Color and higher log levels to stdout
-            .chain(fern::Dispatch::new().chain(std::io::stdout()))
-            // No color and lower log levels to logfile
-            .chain(
-                fern::Dispatch::new()
-                    .format(|out, message, _record| {
-                        out.finish(format_args!(
-                            // TODO: Strip color info
-                            "{}",
-                            message,
-                        ))
-                    })
-                    .chain(fern::log_file(logfile_path)?),
-            )
-            .apply()?,
+            .level_for("launch_", log::LevelFilter::Warn); // Rocket config info
     }
+
+    dispatch
+        // Formatting
+        .format(move |out, message, record| {
+            out.finish(format_args!(
+                "[{}][{}][{}]: {}",
+                chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
+                colors.color(record.level()),
+                record.target(),
+                message,
+            ))
+        })
+        // Color and higher log levels to stdout
+        .chain(fern::Dispatch::new().chain(std::io::stdout()))
+        // No color and lower log levels to logfile
+        .chain(
+            fern::Dispatch::new()
+                .format(|out, message, _record| {
+                    out.finish(format_args!(
+                        // TODO: Strip color info
+                        "{}",
+                        message,
+                    ))
+                })
+                .chain(fern::log_file(logfile_path)?),
+        )
+        .apply()?;
     Ok(())
 }
 

--- a/aw-server/src/logging.rs
+++ b/aw-server/src/logging.rs
@@ -44,37 +44,65 @@ pub fn setup_logger(testing: bool) -> Result<(), fern::InitError> {
         _ => default_log_level,
     };
 
-    fern::Dispatch::new()
-        // Set some Rocket messages to debug level
-        .level(log_level)
-        .level_for("rocket", log::LevelFilter::Warn)
-        .level_for("_", log::LevelFilter::Warn) // Rocket requests
-        .level_for("launch_", log::LevelFilter::Warn) // Rocket config info
-        .format(move |out, message, record| {
-            out.finish(format_args!(
-                "[{}][{}][{}]: {}",
-                chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
-                colors.color(record.level()),
-                record.target(),
-                message,
-            ))
-        })
-        // Color and higher log levels to stdout
-        .chain(fern::Dispatch::new().chain(std::io::stdout()))
-        // No color and lower log levels to logfile
-        .chain(
-            fern::Dispatch::new()
-                .format(|out, message, _record| {
-                    out.finish(format_args!(
-                        // TODO: Strip color info
-                        "{}",
-                        message,
-                    ))
-                })
-                .chain(fern::log_file(logfile_path)?),
-        )
-        .apply()?;
-
+    match log_level {
+        log::LevelFilter::Debug | log::LevelFilter::Trace => fern::Dispatch::new()
+            // Set some Rocket messages to debug level
+            .level(log_level)
+            .format(move |out, message, record| {
+                out.finish(format_args!(
+                    "[{}][{}][{}]: {}",
+                    chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
+                    colors.color(record.level()),
+                    record.target(),
+                    message,
+                ))
+            })
+            // Color and higher log levels to stdout
+            .chain(fern::Dispatch::new().chain(std::io::stdout()))
+            // No color and lower log levels to logfile
+            .chain(
+                fern::Dispatch::new()
+                    .format(|out, message, _record| {
+                        out.finish(format_args!(
+                            // TODO: Strip color info
+                            "{}",
+                            message,
+                        ))
+                    })
+                    .chain(fern::log_file(logfile_path)?),
+            )
+            .apply()?,
+        _ => fern::Dispatch::new()
+            // Set some Rocket messages to debug level
+            .level(log_level)
+            .level_for("rocket", log::LevelFilter::Warn)
+            .level_for("_", log::LevelFilter::Warn) // Rocket requests
+            .level_for("launch_", log::LevelFilter::Warn) // Rocket config info
+            .format(move |out, message, record| {
+                out.finish(format_args!(
+                    "[{}][{}][{}]: {}",
+                    chrono::Local::now().format("%Y-%m-%d %H:%M:%S"),
+                    colors.color(record.level()),
+                    record.target(),
+                    message,
+                ))
+            })
+            // Color and higher log levels to stdout
+            .chain(fern::Dispatch::new().chain(std::io::stdout()))
+            // No color and lower log levels to logfile
+            .chain(
+                fern::Dispatch::new()
+                    .format(|out, message, _record| {
+                        out.finish(format_args!(
+                            // TODO: Strip color info
+                            "{}",
+                            message,
+                        ))
+                    })
+                    .chain(fern::log_file(logfile_path)?),
+            )
+            .apply()?,
+    }
     Ok(())
 }
 

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -63,6 +63,10 @@ async fn main() -> Result<(), rocket::Error> {
 
     logging::setup_logger(testing).expect("Failed to setup logging");
 
+    if testing {
+        info!("Running server in Testing mode");
+    }
+
     let mut config = config::create_config(testing);
 
     // set host if overridden


### PR DESCRIPTION
- Dont filter out Rocket messages when in Debug or Trace log level
- also fixes inverted testing condition when config

Eg logs. - https://github.com/ActivityWatch/aw-webui/actions/runs/3341509927/jobs/5532792619#step:15:16