### PR TITLE
build: downgrade NDK to r21e and added macOS Android build support

### DIFF
--- a/compile-android.sh
+++ b/compile-android.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
 if [ -z "$ANDROID_NDK_HOME" ]; then
     if [ -d `pwd`/"NDK" ]; then
@@ -32,7 +33,7 @@ for archtargetstr in \
     target=$(echo $archtargetstr | cut -d " " -f 2)
     target_underscore=$(echo $target | sed 's/-/_/g')
 
-    NDK_ARCH_DIR="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin"
+    NDK_ARCH_DIR="$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$platform-x86_64/bin"
     echo "Building for $arch..."
 
     if [ -d "$NDK_ARCH_DIR" ]; then

--- a/install-ndk.sh
+++ b/install-ndk.sh
@@ -4,15 +4,20 @@
 
 set -e;
 
+NDK_VERSION=r21e
+
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 project_path="$(readlink -f "$script_dir/.")"
+
+platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
 if [ -z "$ANDROID_NDK_HOME" ]; then
     if [ -d `pwd`/"NDK" ]; then
         echo "Found NDK folder in root, using."
     else
         echo 'ANDROID_NDK_HOME not set, downloading NDK...';
-        wget --no-verbose -O android-ndk.zip https://dl.google.com/android/repository/android-ndk-r25b-linux.zip;
+        # Download Linux NDK or macOS NDK, depending on OS
+        wget --no-verbose -O android-ndk.zip https://dl.google.com/android/repository/android-ndk-$NDK_VERSION-$platform-x86_64.zip;
         unzip -q -d NDK android-ndk.zip;
         ls NDK;
         mv NDK/*/* NDK/;
@@ -22,7 +27,7 @@ fi
 
 # Needed since dependency 'ring' doesn't respect .cargo/config
 echo "Setting up toolchain binary symlinks..."
-NDK_TOOLCHAIN_BIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin
+NDK_TOOLCHAIN_BIN=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$platform-x86_64/bin
 for arch in \
     'aarch64' \
     'x86_64' \
@@ -44,18 +49,18 @@ echo "Creating cargo config..."
 mkdir -p $project_path/.cargo
 echo "
 [target.aarch64-linux-android]
-ar = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar'
-linker = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android26-clang'
+ar = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$platform-x86_64/bin/llvm-ar'
+linker = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$platform-x86_64/bin/aarch64-linux-android26-clang'
 
 [target.armv7-linux-androideabi]
-ar = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar'
-linker = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi-clang'
+ar = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$platform-x86_64/bin/llvm-ar'
+linker = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$platform-x86_64/bin/armv7a-linux-androideabi-clang'
 
 [target.i686-linux-android]
-ar = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar'
-linker = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android26-clang'
+ar = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$platform-x86_64/bin/llvm-ar'
+linker = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$platform-x86_64/bin/i686-linux-android26-clang'
 
 [target.x86_64-linux-android]
-ar = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar'
-linker = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android26-clang'
+ar = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$platform-x86_64/bin/llvm-ar'
+linker = '$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/$platform-x86_64/bin/x86_64-linux-android26-clang'
 " > $project_path/.cargo/config


### PR DESCRIPTION
We briefly had working builds for r25 (https://github.com/ActivityWatch/aw-server-rust/commit/6f1d5b2242ddc7c9cd17580ae4c556a8c210ca55), but they started failing with a weird:

```
  = note: ld: error: unable to find library -lgcc
          clang-14: error: linker command failed with exit code 1 (use -v to see invocation)
```

This change works locally for me (on macOS), hoping it fixes CI too.