### PR TITLE
fix(aw-client-rust): make create_bucket_simple useful

### DIFF
--- a/aw-client-rust/src/lib.rs
+++ b/aw-client-rust/src/lib.rs
@@ -62,10 +62,10 @@ impl AwClient {
         &self,
         bucketname: &str,
         buckettype: &str,
-    ) -> Result<(), reqwest::Error> {
+    ) -> Result<Bucket, reqwest::Error> {
         let bucket = Bucket {
             bid: None,
-            id: bucketname.to_string(),
+            id: format!("{}_{}", bucketname, self.hostname),
             client: self.name.clone(),
             _type: buckettype.to_string(),
             hostname: self.hostname.clone(),
@@ -75,7 +75,8 @@ impl AwClient {
             created: None,
             last_updated: None,
         };
-        self.create_bucket(&bucket)
+        self.create_bucket(&bucket)?;
+        Ok(bucket)
     }
 
     pub fn delete_bucket(&self, bucketname: &str) -> Result<(), reqwest::Error> {


### PR DESCRIPTION
create_bucket_simple should expose the created bucket for later use. This would allow to expose the id, which can be generated based on the bucket name given and the hostname, what in turn leads to simpler creation of a new Bucket, as intended by the function.