### PR TITLE
Linux pathing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,12 @@ all: build
 build: aw-server aw-webui
 
 DESTDIR :=
-PREFIX := /usr/local
+ifeq ($(SUDO_USER),)
+    PREFIX := $(HOME)/.local
+else
+    PREFIX := /usr/local
+endif
+
 
 # Build in release mode by default, unless RELEASE=false
 ifeq ($(RELEASE), false)

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,16 @@ all: build
 build: aw-server aw-webui
 
 DESTDIR :=
-ifeq ($(SUDO_USER),)
-    PREFIX := $(HOME)/.local
+# confirm we are neither root nor running as sudo
+# if not, use XDG_DATA_HOME or ~/.local as default PREFIX
+ifeq ($(SUDO_USER),) && ($(USER),!root)
+	ifeq ($(XDG_DATA_HOME),)
+    	PREFIX ?= $(HOME)/.local
+	else
+		PREFIX ?= $(XDG_DATA_HOME)
+	endif
 else
-    PREFIX := /usr/local
+    PREFIX ?= /usr/local
 endif
 
 


### PR DESCRIPTION
So this changes both the makefile and server code to check both the system data directories and user data directories. It does this without adding any dependencies. 

the makefile now checks if the user is either root or running as sudo, and defaults to the system prefix if so, if not it first checks if `XDG_DATA_HOME` is set and either sets it to to that or the conventional location for it. it also uses `?=` for assignment so that the user can easily override it

the server does a similar set of checks as it does for `XDG_DATA_DIRS` for `XDG_DATA_HOME` and appends it to the `joined` variable

I do think that something like the directories crate might be a better option. Partially because right now we're checking for the directories of each platform on each platform, and partially because `env::home_dir` is deprecated(though for reasons related to it's windows behavior in linux specific code). 

If you would like to switch to directories or another crate for cross platform pathing, I can do it in this PR or make another one if you would prefer to get the current changes into master first