### PR TITLE
ci: pinned tarpaulin version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,8 @@ jobs:
     # feature sets, you need a `.tarpaulin.toml` config file, see
     # the link above for those docs.
     - uses: actions-rs/tarpaulin@v0.1
+      with:
+        version: "0.22.0"  # not latest, due to error/bug in action (after release artifacts changed name?)
 
     # Note: closed-source code needs to provide a token,
     # but open source code does not.


### PR DESCRIPTION
Due to "Couldn't find a release tarball containing binaries for latest".

Probably due to release artifacts/tarballs changing their naming, making the action unable to find the tarball.