### PR TITLE
fix: period_union with empty args

### DIFF
--- a/aw-transform/src/period_union.rs
+++ b/aw-transform/src/period_union.rs
@@ -22,7 +22,7 @@ pub fn period_union(events1: &[Event], events2: &[Event]) -> Vec<Event> {
 
     let mut events_union = Vec::new();
 
-    if ![events1, events2].concat().is_empty() {
+    if !sorted_events.is_empty() {
         events_union.push(sorted_events.pop_front().unwrap())
     }
 


### PR DESCRIPTION
Test: `test_period_union_1st_empty()` would replicate #343 (https://github.com/ActivityWatch/aw-server-rust/issues/343#issuecomment-1475094096)