### PR TITLE
debug: redirect stderr panic log to rust logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aead"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +244,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "log-panics",
  "multipart",
  "openssl-sys",
  "rocket",
@@ -266,6 +282,21 @@ dependencies = [
  "rocket",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -912,6 +943,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,6 +1321,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "log-panics"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
+dependencies = [
+ "backtrace",
+ "log",
+]
+
+[[package]]
 name = "loom"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1380,15 @@ checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
 ]
 
 [[package]]
@@ -1449,6 +1505,15 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1974,6 +2039,12 @@ dependencies = [
  "serde_json",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
 
 [[package]]
 name = "rustix"

--- a/aw-server/Cargo.toml
+++ b/aw-server/Cargo.toml
@@ -32,6 +32,7 @@ toml = "0.7"
 gethostname = "0.4"
 uuid = { version = "1.3", features = ["serde", "v4"] }
 clap = { version = "4.1", features = ["derive", "cargo"] }
+log-panics = { version = "2", features = ["with-backtrace"]}
 
 aw-datastore = { path = "../aw-datastore" }
 aw-models = { path = "../aw-models" }

--- a/aw-server/src/logging.rs
+++ b/aw-server/src/logging.rs
@@ -19,9 +19,6 @@ pub fn setup_logger(testing: bool) -> Result<(), fern::InitError> {
             .to_string(),
     );
 
-    log_panics::Config::new()
-        .backtrace_mode(log_panics::BacktraceMode::Unresolved)
-        .install_panic_hook();
     log_panics::init();
 
     let colors = ColoredLevelConfig::new()

--- a/aw-server/src/logging.rs
+++ b/aw-server/src/logging.rs
@@ -19,6 +19,11 @@ pub fn setup_logger(testing: bool) -> Result<(), fern::InitError> {
             .to_string(),
     );
 
+    log_panics::Config::new()
+        .backtrace_mode(log_panics::BacktraceMode::Unresolved)
+        .install_panic_hook();
+    log_panics::init();
+
     let colors = ColoredLevelConfig::new()
         .debug(Color::White)
         .info(Color::Green)


### PR DESCRIPTION
- panic log from various sites is written to `stderr` by default and due to https://github.com/ActivityWatch/aw-server/issues/27#issue-233126783 its not redirected/piped to `logfile`

eg. log.
```shell
[2023-04-08 19:43:13][[33mWARN[0m][aw_transform::flood]: Gap was of negative duration and could NOT be safely merged (-PT397.291Ss). This warning will only show once per batch.
[2023-04-08 19:43:13][[31mERROR[0m][panic]: thread 'rocket-worker-thread' panicked at 'meow': aw-transform\src\period_union.rs:49
   0: backtrace::backtrace::trace
   1: backtrace::capture::Backtrace::new
   2: <backtrace::capture::Backtrace as core::default::Default>::default
   3: log_panics::Config::install_panic_hook
   4: alloc::boxed::impl$47::call
             at /rustc/1459b3128e288a85fcc4dd1fee7ada2cdcf28794/library\alloc\src\boxed.rs:2002
   5: std::panicking::rust_panic_with_hook
             at /rustc/1459b3128e288a85fcc4dd1fee7ada2cdcf28794/library\std\src\panicking.rs:696
   6: std::panicking::begin_panic_handler::closure$0
             at /rustc/1459b3128e288a85fcc4dd1fee7ada2cdcf28794/library\std\src\panicking.rs:581
   7: std::sys_common::backtrace::__rust_end_short_backtrace<std::panicking::begin_panic_handler::closure_env$0,never$>
             at /rustc/1459b3128e288a85fcc4dd1fee7ada2cdcf28794/library\std\src\sys_common\backtrace.rs:150
   8: std::panicking::begin_panic_handler
             at /rustc/1459b3128e288a85fcc4dd1fee7ada2cdcf28794/library\std\src\panicking.rs:579
   9: core::panicking::panic_fmt
             at /rustc/1459b3128e288a85fcc4dd1fee7ada2cdcf28794/library\core\src\panicking.rs:64
  10: aw_transform::period_union::period_union
  11: aw_query::functions::qfunctions::period_union
  12: aw_query::interpret::interpret_prog
  13: aw_query::interpret::interpret_prog
  14: aw_query::interpret::interpret_prog
  15: aw_query::query
  16: aw_server::endpoints::util::<impl core::convert::Into<aw_server::endpoints::util::HttpErrorJson> for aw_datastore::DatastoreError>::into
  17: rocket::server::<impl rocket::rocket::Rocket<rocket::phase::Orbit>>::http_server::{{closure}}::{{closure}}
  18: rocket::server::hyper_service_fn::{{closure}}::{{closure}}
  19: tokio::runtime::task::core::Core<T,S>::poll
  20: tokio::runtime::task::harness::Harness<T,S>::poll
  21: tokio::runtime::scheduler::multi_thread::worker::Context::run
  22: tokio::runtime::scheduler::multi_thread::worker::Context::run
  23: tokio::macros::scoped_tls::ScopedKey<T>::set
  24: tokio::runtime::scheduler::multi_thread::worker::run
  25: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
  26: tokio::runtime::task::core::Core<T,S>::poll
  27: tokio::runtime::task::harness::Harness<T,S>::poll
  28: tokio::runtime::blocking::pool::Inner::run
  29: std::sys_common::backtrace::__rust_begin_short_backtrace
  30: std::thread::Builder::spawn
  31: alloc::boxed::impl$45::call_once
             at /rustc/1459b3128e288a85fcc4dd1fee7ada2cdcf28794/library\alloc\src\boxed.rs:1988
  32: alloc::boxed::impl$45::call_once
             at /rustc/1459b3128e288a85fcc4dd1fee7ada2cdcf28794/library\alloc\src\boxed.rs:1988
  33: std::sys::windows::thread::impl$0::new::thread_start
             at /rustc/1459b3128e288a85fcc4dd1fee7ada2cdcf28794/library\std\src\sys\windows\thread.rs:56
  34: BaseThreadInitThunk
  35: RtlUserThreadStart
  
[2023-04-08 19:43:13][[31mERROR[0m][_]: Handler [37mquery[0m panicked.
[2023-04-08 19:43:13][[33mWARN[0m][_]: A panic is treated as an internal server error.
[2023-04-08 19:43:13][[33mWARN[0m][_]: No [1;34m500[0m catcher registered. Using Rocket default.
```