### PR TITLE
Split client to async and blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "rocket",
  "serde",
  "serde_json",
+ "tokio",
  "tokio-test",
 ]
 

--- a/aw-client-rust/Cargo.toml
+++ b/aw-client-rust/Cargo.toml
@@ -11,6 +11,7 @@ serde = "1.0"
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 aw-models = { path = "../aw-models" }
+tokio = { version = "1.28.2", features = ["rt"] }
 
 [dev-dependencies]
 aw-datastore = { path = "../aw-datastore" }

--- a/aw-client-rust/src/blocking.rs
+++ b/aw-client-rust/src/blocking.rs
@@ -1,0 +1,77 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::vec::Vec;
+
+use chrono::{DateTime, Utc};
+
+use aw_models::{Bucket, Event};
+
+use super::AwClient as AsyncAwClient;
+
+pub struct AwClient {
+    client: AsyncAwClient,
+    pub baseurl: String,
+    pub name: String,
+    pub hostname: String,
+}
+
+impl std::fmt::Debug for AwClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "AwClient(baseurl={:?})", self.client.baseurl)
+    }
+}
+
+fn block_on<F: Future>(f: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build shell runtime")
+        .block_on(f)
+}
+
+macro_rules! proxy_method
+{
+    ($name:tt, $ret:ty, $($v:ident: $t:ty),*) => {
+        pub fn $name(&self, $($v: $t),*) -> Result<$ret, reqwest::Error>
+        { block_on(self.client.$name($($v),*)) }
+    };
+}
+
+impl AwClient {
+    pub fn new(ip: &str, port: &str, name: &str) -> AwClient {
+        let async_client = AsyncAwClient::new(ip, port, name);
+
+        AwClient {
+            baseurl: async_client.baseurl.clone(),
+            name: async_client.name.clone(),
+            hostname: async_client.hostname.clone(),
+            client: async_client,
+        }
+    }
+
+    proxy_method!(get_bucket, Bucket, bucketname: &str);
+    proxy_method!(get_buckets, HashMap<String, Bucket>,);
+    proxy_method!(create_bucket, (), bucket: &Bucket);
+    proxy_method!(create_bucket_simple, (), bucketname: &str, buckettype: &str);
+    proxy_method!(delete_bucket, (), bucketname: &str);
+    proxy_method!(
+        get_events,
+        Vec<Event>,
+        bucketname: &str,
+        start: Option<DateTime<Utc>>,
+        stop: Option<DateTime<Utc>>,
+        limit: Option<u64>
+    );
+    proxy_method!(insert_event, (), bucketname: &str, event: &Event);
+    proxy_method!(insert_events, (), bucketname: &str, events: Vec<Event>);
+    proxy_method!(
+        heartbeat,
+        (),
+        bucketname: &str,
+        event: &Event,
+        pulsetime: f64
+    );
+    proxy_method!(delete_event, (), bucketname: &str, event_id: i64);
+    proxy_method!(get_event_count, i64, bucketname: &str);
+    proxy_method!(get_info, aw_models::Info,);
+}

--- a/aw-client-rust/tests/test.rs
+++ b/aw-client-rust/tests/test.rs
@@ -8,7 +8,7 @@ extern crate tokio_test;
 
 #[cfg(test)]
 mod test {
-    use aw_client_rust::AwClient;
+    use aw_client_rust::blocking::AwClient;
     use aw_client_rust::Event;
     use chrono::{DateTime, Duration, Utc};
     use serde_json::Map;
@@ -51,7 +51,7 @@ mod test {
         let shutdown_handler = server.shutdown();
 
         thread::spawn(move || {
-            let launch = block_on(server.launch()).unwrap();
+            let _ = block_on(server.launch()).unwrap();
         });
 
         shutdown_handler

--- a/aw-sync/src/accessmethod.rs
+++ b/aw-sync/src/accessmethod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use aw_client_rust::AwClient;
+use aw_client_rust::blocking::AwClient;
 use chrono::{DateTime, Utc};
 use reqwest::StatusCode;
 

--- a/aw-sync/src/main.rs
+++ b/aw-sync/src/main.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 use chrono::{DateTime, Datelike, TimeZone, Utc};
 use clap::{Parser, Subcommand};
 
-use aw_client_rust::AwClient;
+use aw_client_rust::blocking::AwClient;
 
 mod accessmethod;
 mod sync;

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -13,7 +13,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use aw_client_rust::AwClient;
+use aw_client_rust::blocking::AwClient;
 use chrono::{DateTime, Utc};
 
 use aw_datastore::{Datastore, DatastoreError};


### PR DESCRIPTION
The problem is not only that the current functionality is less useful in async context. The client cannot be used in async context at all as is:
https://docs.rs/reqwest/latest/reqwest/blocking/
> Conversely, the functionality in reqwest::blocking must not be executed within an async runtime, or it will panic when attempting to block

I've used tokio's runtime to block because reqwest uses tokio blocking internally as well.
https://github.com/seanmonstar/reqwest/blob/master/src/blocking/wait.rs
It also uses a current thread runtime, but with timeouts. However, the async client specified the timeout already, so it shouldn't matter much.