### PR TITLE
fix: improve AW_WEBUI_DIR handling

### DIFF
--- a/aw-server/build.rs
+++ b/aw-server/build.rs
@@ -1,16 +1,24 @@
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // if aw-webui/dist does not exist or is empty, print a warning
-    let path = std::path::Path::new("../aw-webui/dist");
+    let webui_var = std::env::var("AW_WEBUI_DIR");
+    let path = if let Ok(var_path) = &webui_var {
+        std::path::Path::new(var_path)
+    } else {
+        let path = std::path::Path::new("../aw-webui/dist");
+        // ensure folder exists, since macro requires it
+        std::fs::create_dir_all(path)?;
+        println!("cargo:rustc-env=AW_WEBUI_DIR={}", path.display());
+        path
+    };
+
     let path_index = path.join("index.html");
     if !path_index.exists() {
-        println!("cargo:warning=`./aw-webui/dist` is not built, compiling without webui");
+        println!(
+            "cargo:warning=`{}` is not built, compiling without webui",
+            path.display()
+        );
     }
-
-    // ensure folder exists, since macro requires it
-    std::fs::create_dir_all(path)?;
-    println!("cargo:rustc-env=AW_WEBUI_DIR=../aw-webui/dist");
 
     Ok(())
 }


### PR DESCRIPTION
Otherwise, `../aw-webui/dist` is always created which contradicts the flexibility from the env variable. Also, if `AW_WEBUI_DIR` is already and explicitly set then it supposedly means that the build runner has taken care of the matter.

Follow up on https://github.com/ActivityWatch/aw-server-rust/pull/385