### PR TITLE
feat(sync): moved logic in sync-test scripts into rust, enabling sync with a single command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,16 +273,20 @@ dependencies = [
 name = "aw-sync"
 version = "0.1.0"
 dependencies = [
+ "appdirs",
  "aw-client-rust",
  "aw-datastore",
  "aw-models",
  "aw-server",
  "chrono",
  "clap",
+ "dirs 3.0.2",
+ "gethostname",
  "log",
  "reqwest",
  "serde",
  "serde_json",
+ "toml",
 ]
 
 [[package]]
@@ -621,6 +625,15 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys",
 ]
 
 [[package]]
@@ -2153,7 +2166,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
 dependencies = [
- "dirs",
+ "dirs 4.0.0",
 ]
 
 [[package]]

--- a/aw-server/src/dirs.rs
+++ b/aw-server/src/dirs.rs
@@ -53,15 +53,15 @@ pub fn get_cache_dir() -> Result<PathBuf, ()> {
 }
 
 #[cfg(not(target_os = "android"))]
-pub fn get_log_dir() -> Result<PathBuf, ()> {
+pub fn get_log_dir(module: &str) -> Result<PathBuf, ()> {
     let mut dir = appdirs::user_log_dir(Some("activitywatch"), None)?;
-    dir.push("aw-server-rust");
+    dir.push(module);
     fs::create_dir_all(dir.clone()).expect("Unable to create log dir");
     Ok(dir)
 }
 
 #[cfg(target_os = "android")]
-pub fn get_log_dir() -> Result<PathBuf, ()> {
+pub fn get_log_dir(module: &str) -> Result<PathBuf, ()> {
     panic!("not implemented on Android");
 }
 
@@ -87,7 +87,7 @@ fn test_get_dirs() {
     set_android_data_dir("/test");
 
     get_cache_dir().unwrap();
-    get_log_dir().unwrap();
+    get_log_dir("aw-server-rust").unwrap();
     db_path(true).unwrap();
     db_path(false).unwrap();
 }

--- a/aw-server/src/logging.rs
+++ b/aw-server/src/logging.rs
@@ -5,19 +5,17 @@ use fern::colors::{Color, ColoredLevelConfig};
 
 use crate::dirs;
 
-pub fn setup_logger(testing: bool, verbose: bool) -> Result<(), fern::InitError> {
+pub fn setup_logger(module: &str, testing: bool, verbose: bool) -> Result<(), fern::InitError> {
     let mut logfile_path: PathBuf =
-        dirs::get_log_dir().expect("Unable to get log dir to store logs in");
+        dirs::get_log_dir(module).expect("Unable to get log dir to store logs in");
     fs::create_dir_all(logfile_path.clone()).expect("Unable to create folder for logs");
-    logfile_path.push(
-        chrono::Local::now()
-            .format(if !testing {
-                "aw-server_%Y-%m-%dT%H-%M-%S%z.log"
-            } else {
-                "aw-server-testing_%Y-%m-%dT%H-%M-%S%z.log"
-            })
-            .to_string(),
-    );
+    let filename = if !testing {
+        format!("{}_%Y-%m-%dT%H-%M-%S%z.log", module)
+    } else {
+        format!("{}-testing_%Y-%m-%dT%H-%M-%S%z.log", module)
+    };
+
+    logfile_path.push(chrono::Local::now().format(&filename).to_string());
 
     log_panics::init();
 
@@ -93,6 +91,6 @@ mod tests {
     #[ignore]
     #[test]
     fn test_setup_logger() {
-        setup_logger(true, true).unwrap();
+        setup_logger("aw-server-rust", true, true).unwrap();
     }
 }

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -70,7 +70,8 @@ async fn main() -> Result<(), rocket::Error> {
         testing = true;
     }
 
-    logging::setup_logger(testing, opts.verbose).expect("Failed to setup logging");
+    logging::setup_logger("aw-server-rust", testing, opts.verbose)
+        .expect("Failed to setup logging");
 
     if testing {
         info!("Running server in Testing mode");

--- a/aw-sync/Cargo.toml
+++ b/aw-sync/Cargo.toml
@@ -14,12 +14,16 @@ path = "src/main.rs"
 
 [dependencies]
 log = "0.4"
+toml = "0.7"
 chrono = { version = "0.4", features = ["serde"] }
 serde = "1.0"
 serde_json = "1.0"
 reqwest = { version = "0.11", features = ["json", "blocking"] }
 clap = { version = "4.1", features = ["derive"] }
+appdirs = "0.2.0"
+dirs = "3.0.2"
 aw-server = { path = "../aw-server" }
 aw-models = { path = "../aw-models" }
 aw-datastore = { path = "../aw-datastore" }
 aw-client-rust = { path = "../aw-client-rust" }
+gethostname = "0.4.3"

--- a/aw-sync/src/dirs.rs
+++ b/aw-sync/src/dirs.rs
@@ -3,6 +3,8 @@ use std::fs;
 use std::path::PathBuf;
 
 // TODO: This could be refactored to share logic with aw-server/src/dirs.rs
+// TODO: add proper config support
+#[allow(dead_code)]
 pub fn get_config_dir() -> Result<PathBuf, ()> {
     let mut dir = appdirs::user_config_dir(Some("activitywatch"), None, false)?;
     dir.push("aw-sync");

--- a/aw-sync/src/dirs.rs
+++ b/aw-sync/src/dirs.rs
@@ -11,18 +11,15 @@ pub fn get_config_dir() -> Result<PathBuf, ()> {
 }
 
 pub fn get_server_config_path(testing: bool) -> Result<PathBuf, ()> {
-    home_dir()
-        .map(|dir| {
-            dir.join(".config/activitywatch/aw-server-rust")
-                .join(if testing {
-                    "config-testing.toml"
-                } else {
-                    "config.toml"
-                })
-        })
-        .ok_or(())
+    let dir = aw_server::dirs::get_config_dir()?;
+    Ok(dir.join(if testing {
+        "config-testing.toml"
+    } else {
+        "config.toml"
+    }))
 }
 
 pub fn get_sync_dir() -> Result<PathBuf, ()> {
+    // TODO: make this configurable
     home_dir().map(|p| p.join("ActivityWatchSync")).ok_or(())
 }

--- a/aw-sync/src/dirs.rs
+++ b/aw-sync/src/dirs.rs
@@ -1,0 +1,28 @@
+use dirs::home_dir;
+use std::fs;
+use std::path::PathBuf;
+
+// TODO: This could be refactored to share logic with aw-server/src/dirs.rs
+pub fn get_config_dir() -> Result<PathBuf, ()> {
+    let mut dir = appdirs::user_config_dir(Some("activitywatch"), None, false)?;
+    dir.push("aw-sync");
+    fs::create_dir_all(dir.clone()).expect("Unable to create config dir");
+    Ok(dir)
+}
+
+pub fn get_server_config_path(testing: bool) -> Result<PathBuf, ()> {
+    home_dir()
+        .map(|dir| {
+            dir.join(".config/activitywatch/aw-server-rust")
+                .join(if testing {
+                    "config-testing.toml"
+                } else {
+                    "config.toml"
+                })
+        })
+        .ok_or(())
+}
+
+pub fn get_sync_dir() -> Result<PathBuf, ()> {
+    home_dir().map(|p| p.join("ActivityWatchSync")).ok_or(())
+}

--- a/aw-sync/src/lib.rs
+++ b/aw-sync/src/lib.rs
@@ -10,5 +10,12 @@ pub use sync::sync_datastores;
 pub use sync::sync_run;
 pub use sync::SyncSpec;
 
+mod sync_wrapper;
+pub use sync_wrapper::push;
+pub use sync_wrapper::{pull, pull_all};
+
 mod accessmethod;
 pub use accessmethod::AccessMethod;
+
+mod dirs;
+mod util;

--- a/aw-sync/src/main.rs
+++ b/aw-sync/src/main.rs
@@ -107,7 +107,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     info!("Started aw-sync...");
 
-    aw_server::logging::setup_logger(true, verbose).expect("Failed to setup logging");
+    aw_server::logging::setup_logger("aw-sync", opts.testing, verbose)
+        .expect("Failed to setup logging");
 
     let port = opts
         .port
@@ -129,6 +130,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     }
                 }
                 None => {
+                    info!("Pulling from all hosts");
                     sync_wrapper::pull_all(&client)?;
                 }
             }
@@ -147,7 +149,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             sync_db,
         } => {
             let sync_directory = if sync_dir.is_empty() {
-                println!("No sync directory specified, exiting...");
+                error!("No sync directory specified, exiting...");
                 std::process::exit(1);
             } else {
                 Path::new(&sync_dir)

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -9,7 +9,6 @@ extern crate chrono;
 extern crate reqwest;
 extern crate serde_json;
 
-use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -65,7 +64,7 @@ pub fn sync_run(client: &AwClient, sync_spec: &SyncSpec, mode: SyncMode) -> Resu
 
     // FIXME: Bad device_id assumption?
     let ds_localremote = setup_local_remote(sync_spec.path.as_path(), device_id)?;
-    let remote_dbfiles = find_remotes_nonlocal(
+    let remote_dbfiles = crate::util::find_remotes_nonlocal(
         sync_spec.path.as_path(),
         device_id,
         sync_spec.path_db.as_ref(),
@@ -138,7 +137,7 @@ pub fn list_buckets(client: &AwClient) -> Result<(), String> {
     let device_id = info.device_id.as_str();
     let ds_localremote = setup_local_remote(sync_directory, device_id)?;
 
-    let remote_dbfiles = find_remotes_nonlocal(sync_directory, device_id, None);
+    let remote_dbfiles = crate::util::find_remotes_nonlocal(sync_directory, device_id, None);
     info!("Found remotes: {:?}", remote_dbfiles);
 
     // TODO: Check for compatible remote db version before opening
@@ -173,47 +172,6 @@ fn setup_local_remote(path: &Path, device_id: &str) -> Result<Datastore, String>
 
     let ds_localremote = create_datastore(&dbfile);
     Ok(ds_localremote)
-}
-
-/// Returns a list of all remote dbs
-fn find_remotes(sync_directory: &Path) -> std::io::Result<Vec<PathBuf>> {
-    let dbs = fs::read_dir(sync_directory)?
-        .map(|res| res.ok().unwrap().path())
-        .filter(|p| p.is_dir())
-        .flat_map(|d| fs::read_dir(d).unwrap())
-        .map(|res| res.ok().unwrap().path())
-        .filter(|path| path.extension().unwrap_or_else(|| OsStr::new("")) == "db")
-        .collect();
-    Ok(dbs)
-}
-
-/// Returns a list of all remotes, excluding local ones
-fn find_remotes_nonlocal(
-    sync_directory: &Path,
-    device_id: &str,
-    sync_db: Option<&PathBuf>,
-) -> Vec<PathBuf> {
-    let remotes_all = find_remotes(sync_directory).unwrap();
-    remotes_all
-        .into_iter()
-        // Filter out own remote
-        .filter(|path| {
-            !(path
-                .clone()
-                .into_os_string()
-                .into_string()
-                .unwrap()
-                .contains(device_id))
-        })
-        // If sync_db is Some, return only remotes in that path
-        .filter(|path| {
-            if let Some(sync_db) = sync_db {
-                path.starts_with(sync_db)
-            } else {
-                true
-            }
-        })
-        .collect()
 }
 
 pub fn create_datastore(path: &Path) -> Datastore {

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -55,7 +55,7 @@ impl Default for SyncSpec {
 }
 
 /// Performs a single sync pass
-pub fn sync_run(client: AwClient, sync_spec: &SyncSpec, mode: SyncMode) -> Result<(), String> {
+pub fn sync_run(client: &AwClient, sync_spec: &SyncSpec, mode: SyncMode) -> Result<(), String> {
     let info = client.get_info().map_err(|e| e.to_string())?;
 
     // FIXME: Here it is assumed that the device_id for the local server is the one used by
@@ -100,14 +100,14 @@ pub fn sync_run(client: AwClient, sync_spec: &SyncSpec, mode: SyncMode) -> Resul
     if mode == SyncMode::Pull || mode == SyncMode::Both {
         info!("Pulling...");
         for ds_from in &ds_remotes {
-            sync_datastores(ds_from, &client, false, None, sync_spec);
+            sync_datastores(ds_from, client, false, None, sync_spec);
         }
     }
 
     // Push local server buckets to sync folder
     if mode == SyncMode::Push || mode == SyncMode::Both {
         info!("Pushing...");
-        sync_datastores(&client, &ds_localremote, true, Some(device_id), sync_spec);
+        sync_datastores(client, &ds_localremote, true, Some(device_id), sync_spec);
     }
 
     // Close open database connections

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -129,7 +129,9 @@ pub fn sync_run(client: AwClient, sync_spec: &SyncSpec, mode: SyncMode) -> Resul
 }
 
 #[allow(dead_code)]
-pub fn list_buckets(client: &AwClient, sync_directory: &Path) -> Result<(), String> {
+pub fn list_buckets(client: &AwClient) -> Result<(), String> {
+    let sync_directory = crate::dirs::get_sync_dir().map_err(|_| "Could not get sync dir")?;
+    let sync_directory = sync_directory.as_path();
     let info = client.get_info().map_err(|e| e.to_string())?;
 
     // FIXME: Incorrect device_id assumption?

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -28,6 +28,7 @@ pub enum SyncMode {
     Both,
 }
 
+#[derive(Debug)]
 pub struct SyncSpec {
     /// Path of sync folder
     pub path: PathBuf,

--- a/aw-sync/src/sync_wrapper.rs
+++ b/aw-sync/src/sync_wrapper.rs
@@ -4,11 +4,10 @@ use std::fs;
 use std::net::TcpStream;
 
 use crate::sync::{sync_run, SyncMode, SyncSpec};
-use crate::util::{get_hostname, get_remotes, get_server_port};
 use aw_client_rust::blocking::AwClient;
 
 pub fn pull_all(testing: bool) -> Result<(), Box<dyn Error>> {
-    let hostnames = get_remotes()?;
+    let hostnames = crate::util::get_remotes()?;
     for host in hostnames {
         pull(&host, testing)?
     }
@@ -19,7 +18,7 @@ pub fn pull(host: &str, testing: bool) -> Result<(), Box<dyn Error>> {
     info!("Pulling data from sync server {}", host);
 
     // Port of the main server
-    let port = get_server_port(testing)?;
+    let port = crate::util::get_server_port(testing)?;
 
     // Check if server is running
     if TcpStream::connect(("localhost", port)).is_err() {
@@ -78,8 +77,8 @@ pub fn pull(host: &str, testing: bool) -> Result<(), Box<dyn Error>> {
 }
 
 pub fn push(testing: bool) -> Result<(), Box<dyn Error>> {
-    let hostname = get_hostname()?;
-    let port = get_server_port(testing)?.to_string();
+    let hostname = crate::util::get_hostname()?;
+    let port = crate::util::get_server_port(testing)?.to_string();
 
     let sync_dir = crate::dirs::get_sync_dir()
         .map_err(|_| "Could not get sync dir")?

--- a/aw-sync/src/sync_wrapper.rs
+++ b/aw-sync/src/sync_wrapper.rs
@@ -1,0 +1,103 @@
+use std::boxed::Box;
+use std::error::Error;
+use std::fs;
+use std::net::TcpStream;
+
+use crate::sync::{sync_run, SyncMode, SyncSpec};
+use crate::util::{get_hostname, get_remotes, get_server_port};
+use aw_client_rust::blocking::AwClient;
+
+pub fn pull_all(testing: bool) -> Result<(), Box<dyn Error>> {
+    let hostnames = get_remotes()?;
+    for host in hostnames {
+        pull(&host, testing)?
+    }
+    Ok(())
+}
+
+pub fn pull(host: &str, testing: bool) -> Result<(), Box<dyn Error>> {
+    info!("Pulling data from sync server {}", host);
+
+    // Port of the main server
+    let port = get_server_port(testing)?;
+
+    // Check if server is running
+    if TcpStream::connect(("localhost", port)).is_err() {
+        return Err(format!("Local server {}:{} not running", host, port).into());
+    }
+
+    // Path to the sync folder
+    // Sync folder is structured ./{hostname}/{device_id}/test.db
+    let sync_root_dir = crate::dirs::get_sync_dir().map_err(|_| "Could not get sync dir")?;
+    let sync_dir = sync_root_dir.join(host);
+    let dbs = fs::read_dir(&sync_dir)?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().is_dir())
+        .map(|entry| fs::read_dir(entry.path()))
+        .filter_map(Result::ok)
+        .flatten()
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry.path().is_file()
+                && entry.path().extension().and_then(|os_str| os_str.to_str()) == Some("db")
+        })
+        .collect::<Vec<_>>();
+
+    // filter out dbs that are smaller than 50kB (workaround for trying to sync empty database
+    // files that are spuriously created somewhere)
+    let dbs = dbs
+        .into_iter()
+        .filter(|entry| entry.metadata().map(|m| m.len() > 50_000).unwrap_or(false))
+        .collect::<Vec<_>>();
+
+    // if more than one db, error
+    if dbs.len() > 1 {
+        return Err("More than one db found in sync folder".into());
+    }
+    // if no db, error
+    if dbs.is_empty() {
+        return Err(format!("No db found in sync folder {:?}", sync_dir).into());
+    }
+
+    for db in dbs {
+        let client = AwClient::new("localhost", port.to_string().as_str(), "aw-sync");
+        let sync_spec = SyncSpec {
+            path: sync_dir.clone(),
+            path_db: Some(db.path().clone()),
+            buckets: Some(vec![
+                format!("aw-watcher-window_{}", host),
+                format!("aw-watcher-afk_{}", host),
+            ]),
+            start: None,
+        };
+        info!("Pulling data with spec {:?}", sync_spec);
+        sync_run(client, &sync_spec, SyncMode::Pull)?;
+    }
+
+    Ok(())
+}
+
+pub fn push(testing: bool) -> Result<(), Box<dyn Error>> {
+    let hostname = get_hostname()?;
+    let port = get_server_port(testing)?.to_string();
+
+    // TODO: Make this configurable
+    let sync_dir = dirs::home_dir()
+        .unwrap()
+        .join("ActivityWatchSync")
+        .join(&hostname);
+
+    let client = AwClient::new("localhost", port.as_str(), "aw-sync");
+    let sync_spec = SyncSpec {
+        path: sync_dir,
+        path_db: None,
+        buckets: Some(vec![
+            format!("aw-watcher-window_{}", hostname),
+            format!("aw-watcher-afk_{}", hostname),
+        ]),
+        start: None,
+    };
+    sync_run(client, &sync_spec, SyncMode::Push)?;
+
+    Ok(())
+}

--- a/aw-sync/src/sync_wrapper.rs
+++ b/aw-sync/src/sync_wrapper.rs
@@ -81,10 +81,8 @@ pub fn push(testing: bool) -> Result<(), Box<dyn Error>> {
     let hostname = get_hostname()?;
     let port = get_server_port(testing)?.to_string();
 
-    // TODO: Make this configurable
-    let sync_dir = dirs::home_dir()
-        .unwrap()
-        .join("ActivityWatchSync")
+    let sync_dir = crate::dirs::get_sync_dir()
+        .map_err(|_| "Could not get sync dir")?
         .join(&hostname);
 
     let client = AwClient::new("localhost", port.as_str(), "aw-sync");

--- a/aw-sync/src/util.rs
+++ b/aw-sync/src/util.rs
@@ -1,8 +1,10 @@
 use std::boxed::Box;
 use std::error::Error;
+use std::ffi::OsStr;
 use std::fs;
 use std::fs::File;
 use std::io::Read;
+use std::path::{Path, PathBuf};
 
 pub fn get_hostname() -> Result<String, Box<dyn Error>> {
     let hostname = gethostname::gethostname()
@@ -33,12 +35,42 @@ pub fn get_server_port(testing: bool) -> Result<u16, Box<dyn Error>> {
     Ok(port)
 }
 
+/// Check if a directory contains a .db file
+fn contains_db_file(dir: &std::path::Path) -> bool {
+    fs::read_dir(dir)
+        .ok()
+        .map(|entries| {
+            entries.filter_map(Result::ok).any(|entry| {
+                entry
+                    .path()
+                    .extension()
+                    .map(|ext| ext == "db")
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+/// Check if a directory contains a subdirectory that contains a .db file
+fn contains_subdir_with_db_file(dir: &std::path::Path) -> bool {
+    fs::read_dir(dir)
+        .ok()
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .any(|entry| entry.path().is_dir() && contains_db_file(&entry.path()))
+        })
+        .unwrap_or(false)
+}
+
 /// Return all remotes in the sync folder
+/// Only returns folders that match ./{host}/{device_id}/*.db
+// TODO: share logic with find_remotes and find_remotes_nonlocal
 pub fn get_remotes() -> Result<Vec<String>, Box<dyn Error>> {
     let sync_root_dir = crate::dirs::get_sync_dir().map_err(|_| "Could not get sync dir")?;
     let hostnames = fs::read_dir(sync_root_dir)?
         .filter_map(Result::ok)
-        .filter(|entry| entry.path().is_dir())
+        .filter(|entry| entry.path().is_dir() && contains_subdir_with_db_file(&entry.path()))
         .filter_map(|entry| {
             entry
                 .path()
@@ -48,4 +80,45 @@ pub fn get_remotes() -> Result<Vec<String>, Box<dyn Error>> {
         .collect();
     info!("Found remotes: {:?}", hostnames);
     Ok(hostnames)
+}
+
+/// Returns a list of all remote dbs
+fn find_remotes(sync_directory: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let dbs = fs::read_dir(sync_directory)?
+        .map(|res| res.ok().unwrap().path())
+        .filter(|p| p.is_dir())
+        .flat_map(|d| fs::read_dir(d).unwrap())
+        .map(|res| res.ok().unwrap().path())
+        .filter(|path| path.extension().unwrap_or_else(|| OsStr::new("")) == "db")
+        .collect();
+    Ok(dbs)
+}
+
+/// Returns a list of all remotes, excluding local ones
+pub fn find_remotes_nonlocal(
+    sync_directory: &Path,
+    device_id: &str,
+    sync_db: Option<&PathBuf>,
+) -> Vec<PathBuf> {
+    let remotes_all = find_remotes(sync_directory).unwrap();
+    remotes_all
+        .into_iter()
+        // Filter out own remote
+        .filter(|path| {
+            !(path
+                .clone()
+                .into_os_string()
+                .into_string()
+                .unwrap()
+                .contains(device_id))
+        })
+        // If sync_db is Some, return only remotes in that path
+        .filter(|path| {
+            if let Some(sync_db) = sync_db {
+                path.starts_with(sync_db)
+            } else {
+                true
+            }
+        })
+        .collect()
 }

--- a/aw-sync/src/util.rs
+++ b/aw-sync/src/util.rs
@@ -1,0 +1,52 @@
+use super::dirs::get_server_config_path;
+use std::boxed::Box;
+use std::error::Error;
+use std::fs::File;
+use std::io::Read;
+use std::{fs, path::PathBuf};
+
+pub fn get_hostname() -> Result<String, Box<dyn Error>> {
+    let hostname = gethostname::gethostname()
+        .into_string()
+        .map_err(|_| "Failed to convert hostname to string")?;
+    Ok(hostname)
+}
+
+/// Returns the port of the local aw-server instance
+pub fn get_server_port(testing: bool) -> Result<u16, Box<dyn Error>> {
+    // TODO: get aw-server config more reliably
+    let aw_server_conf =
+        get_server_config_path(testing).map_err(|_| "Could not get aw-server config path")?;
+    let fallback: u16 = if testing { 5666 } else { 5600 };
+    let port = if aw_server_conf.exists() {
+        let mut file = File::open(&aw_server_conf)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        let value: toml::Value = toml::from_str(&contents)?;
+        value
+            .get("port")
+            .and_then(|v| v.as_integer())
+            .map(|v| v as u16)
+            .unwrap_or(fallback)
+    } else {
+        fallback
+    };
+    Ok(port)
+}
+
+/// Return all remotes in the sync folder
+pub fn get_remotes() -> Result<Vec<String>, Box<dyn Error>> {
+    let sync_root_dir = crate::dirs::get_sync_dir().map_err(|_| "Could not get sync dir")?;
+    let hostnames = fs::read_dir(&sync_root_dir)?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().is_dir())
+        .filter_map(|entry| {
+            entry
+                .path()
+                .file_name()
+                .and_then(|os_str| os_str.to_str().map(String::from))
+        })
+        .collect();
+    info!("Found remotes: {:?}", hostnames);
+    Ok(hostnames)
+}

--- a/aw-sync/src/util.rs
+++ b/aw-sync/src/util.rs
@@ -1,9 +1,8 @@
-use super::dirs::get_server_config_path;
 use std::boxed::Box;
 use std::error::Error;
+use std::fs;
 use std::fs::File;
 use std::io::Read;
-use std::{fs, path::PathBuf};
 
 pub fn get_hostname() -> Result<String, Box<dyn Error>> {
     let hostname = gethostname::gethostname()
@@ -15,8 +14,8 @@ pub fn get_hostname() -> Result<String, Box<dyn Error>> {
 /// Returns the port of the local aw-server instance
 pub fn get_server_port(testing: bool) -> Result<u16, Box<dyn Error>> {
     // TODO: get aw-server config more reliably
-    let aw_server_conf =
-        get_server_config_path(testing).map_err(|_| "Could not get aw-server config path")?;
+    let aw_server_conf = crate::dirs::get_server_config_path(testing)
+        .map_err(|_| "Could not get aw-server config path")?;
     let fallback: u16 = if testing { 5666 } else { 5600 };
     let port = if aw_server_conf.exists() {
         let mut file = File::open(&aw_server_conf)?;
@@ -37,7 +36,7 @@ pub fn get_server_port(testing: bool) -> Result<u16, Box<dyn Error>> {
 /// Return all remotes in the sync folder
 pub fn get_remotes() -> Result<Vec<String>, Box<dyn Error>> {
     let sync_root_dir = crate::dirs::get_sync_dir().map_err(|_| "Could not get sync dir")?;
-    let hostnames = fs::read_dir(&sync_root_dir)?
+    let hostnames = fs::read_dir(sync_root_dir)?
         .filter_map(Result::ok)
         .filter(|entry| entry.path().is_dir())
         .filter_map(|entry| {

--- a/aw-sync/test-sync-pull.sh
+++ b/aw-sync/test-sync-pull.sh
@@ -34,11 +34,12 @@ function sync_host() {
             continue
         fi
 
-        AWSYNCPARAMS="--port $PORT --sync-dir $SYNCDIR --sync-db $db"
+        AWSYNC_ARGS="--port $PORT"
+        AWSYNC_ARGS_ADV="--sync-dir $SYNCDIR --sync-db $db"
         BUCKETS="aw-watcher-window_$host,aw-watcher-afk_$host"
 
         echo "Syncing $db to $host"
-        cargo run --bin aw-sync -- $AWSYNCPARAMS sync-advanced --mode pull --buckets $BUCKETS
+        cargo run --bin aw-sync -- $AWSYNC_ARGS sync-advanced $AWSYNC_ARGS_ADV --mode pull --buckets $BUCKETS
         # TODO: If there are no buckets from the expected host, emit a warning at the end.
         #       (push-script should not have created them to begin with)
     done

--- a/aw-sync/test-sync-pull.sh
+++ b/aw-sync/test-sync-pull.sh
@@ -38,7 +38,7 @@ function sync_host() {
         BUCKETS="aw-watcher-window_$host,aw-watcher-afk_$host"
 
         echo "Syncing $db to $host"
-        cargo run --bin aw-sync -- $AWSYNCPARAMS sync --mode pull --buckets $BUCKETS
+        cargo run --bin aw-sync -- $AWSYNCPARAMS sync-advanced --mode pull --buckets $BUCKETS
         # TODO: If there are no buckets from the expected host, emit a warning at the end.
         #       (push-script should not have created them to begin with)
     done

--- a/aw-sync/test-sync-push.sh
+++ b/aw-sync/test-sync-push.sh
@@ -25,7 +25,8 @@ else
 fi
 
 SYNCDIR="$HOME/ActivityWatchSync/$HOSTNAME"
-AWSYNCPARAMS="--port $PORT --sync-dir $SYNCDIR"
+AWSYNC_ARGS="--port $PORT"
+AWSYNC_ARGS_ADV="--sync-dir $SYNCDIR"
 
 # NOTE: Only sync window and AFK buckets, for now
-cargo run --bin aw-sync --release -- $AWSYNCPARAMS sync-advanced --mode push --buckets aw-watcher-window_$HOSTNAME,aw-watcher-afk_$HOSTNAME
+cargo run --bin aw-sync --release -- $AWSYNC_ARGS sync-advanced $AWSYNC_ARGS_ADV --mode push --buckets aw-watcher-window_$HOSTNAME,aw-watcher-afk_$HOSTNAME

--- a/aw-sync/test-sync-push.sh
+++ b/aw-sync/test-sync-push.sh
@@ -28,4 +28,4 @@ SYNCDIR="$HOME/ActivityWatchSync/$HOSTNAME"
 AWSYNCPARAMS="--port $PORT --sync-dir $SYNCDIR"
 
 # NOTE: Only sync window and AFK buckets, for now
-cargo run --bin aw-sync --release -- $AWSYNCPARAMS sync --mode push --buckets aw-watcher-window_$HOSTNAME,aw-watcher-afk_$HOSTNAME
+cargo run --bin aw-sync --release -- $AWSYNCPARAMS sync-advanced --mode push --buckets aw-watcher-window_$HOSTNAME,aw-watcher-afk_$HOSTNAME


### PR DESCRIPTION
## Goals

- [x] Run a full sync as simple as: `cargo run --bin aw-sync -- sync` or simply `aw-sync sync`.
- [ ] Make it possible to run as a daemon, which regularly syncs on its own (started by aw-qt) 