### PR TITLE
perf: improve performance of filter_period_intersect

### DIFF
--- a/aw-query/src/functions.rs
+++ b/aw-query/src/functions.rs
@@ -506,7 +506,7 @@ mod qfunctions {
         let events: Vec<Event> = (&args[0]).try_into()?;
         let filter_events: Vec<Event> = (&args[1]).try_into()?;
 
-        let mut filtered_events = aw_transform::filter_period_intersect(&events, &filter_events);
+        let mut filtered_events = aw_transform::filter_period_intersect(events, filter_events);
         let mut filtered_tagged_events = Vec::new();
         for event in filtered_events.drain(..) {
             filtered_tagged_events.push(DataType::Event(event));

--- a/aw-transform/benches/bench.rs
+++ b/aw-transform/benches/bench.rs
@@ -45,7 +45,7 @@ fn bench_filter_period_intersect(c: &mut Criterion) {
     c.bench_function("1000 events", |b| {
         b.iter(|| {
             let events1 = create_events(1000);
-            filter_period_intersect(&events1, &events2);
+            filter_period_intersect(events1, events2.clone());
         })
     });
 }

--- a/aw-transform/src/filter_period.rs
+++ b/aw-transform/src/filter_period.rs
@@ -32,7 +32,6 @@ pub fn filter_period_intersect(events: Vec<Event>, filter_events: Vec<Event>) ->
     let mut cur_filter_event = filter_events_iter.next().unwrap();
 
     loop {
-        // TODO: what about duration = 0?
         let event_endtime = cur_event.calculate_endtime();
         let filter_endtime = cur_filter_event.calculate_endtime();
         if cur_event.duration == Duration::seconds(0) || event_endtime <= cur_filter_event.timestamp {

--- a/aw-transform/src/filter_period.rs
+++ b/aw-transform/src/filter_period.rs
@@ -34,7 +34,8 @@ pub fn filter_period_intersect(events: Vec<Event>, filter_events: Vec<Event>) ->
     loop {
         let event_endtime = cur_event.calculate_endtime();
         let filter_endtime = cur_filter_event.calculate_endtime();
-        if cur_event.duration == Duration::seconds(0) || event_endtime <= cur_filter_event.timestamp {
+        if cur_event.duration == Duration::seconds(0) || event_endtime <= cur_filter_event.timestamp
+        {
             match events_iter.next() {
                 Some(e) => {
                     cur_event = e;
@@ -57,7 +58,7 @@ pub fn filter_period_intersect(events: Vec<Event>, filter_events: Vec<Event>) ->
         e.timestamp = std::cmp::max(e.timestamp, cur_filter_event.timestamp);
         let endtime = std::cmp::min(event_endtime, filter_endtime);
         e.duration = endtime - e.timestamp;
-        
+
         // trim current event
         let old_timestamp = cur_event.timestamp;
         cur_event.timestamp = e.timestamp + e.duration;
@@ -104,7 +105,8 @@ mod tests {
             data: json_map! {"test": json!(1)},
         };
 
-        let filtered_events = filter_period_intersect(vec![e1, e2, e3, e4, e5], vec![filter_event.clone()]);
+        let filtered_events =
+            filter_period_intersect(vec![e1, e2, e3, e4, e5], vec![filter_event.clone()]);
         assert_eq!(filtered_events.len(), 3);
         assert_eq!(filtered_events[0].duration, Duration::milliseconds(500));
         assert_eq!(filtered_events[1].duration, Duration::milliseconds(1000));


### PR DESCRIPTION
In general, this reduces complexity of O(n^2) to O(n lgn).
From the benchmark we can see the performance gain:
```bash
     Running benches/bench.rs (target/release/deps/bench-a5f1a4e304f6ce84)
Gnuplot not found, using plotters backend
1000 events             time:   [443.46 µs 444.09 µs 444.76 µs]
                        change: [-92.832% -92.611% -92.413%] (p = 0.00 < 0.05)
                        Performance has improved.
```