### PR TITLE
Add sd-notify

### DIFF
--- a/aw-server.service
+++ b/aw-server.service
@@ -14,12 +14,12 @@
 #
 
 [Service]
-Type=simple
+Type=notify
 ExecStart=aw-server
 
 [Unit]
 Description=ActivityWatch Server (Rust implementation)
-Wants=network.target
+After=network.target
 
 [Install]
 WantedBy=default.target

--- a/aw-server/Cargo.toml
+++ b/aw-server/Cargo.toml
@@ -35,6 +35,9 @@ aw-models = { path = "../aw-models" }
 aw-transform = { path = "../aw-transform" }
 aw-query = { path = "../aw-query" }
 
+[target.'cfg(target_os="linux")'.dependencies]
+sd-notify = "0.4.2"
+
 [target.'cfg(all(target_os="linux", target_arch="x86"))'.dependencies]
 jemallocator = "0.5.0"
 

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -9,6 +9,8 @@ use clap::Parser;
 
 use aw_server::*;
 
+#[cfg(target_os = "linux")]
+use sd_notify::NotifyState;
 #[cfg(all(target_os = "linux", target_arch = "x86"))]
 extern crate jemallocator;
 #[cfg(all(target_os = "linux", target_arch = "x86"))]
@@ -147,9 +149,12 @@ async fn main() -> Result<(), rocket::Error> {
         device_id,
     };
 
-    let _ = endpoints::build_rocket(server_state, config)
-        .launch()
+    let _rocket = endpoints::build_rocket(server_state, config)
+        .ignite()
         .await?;
+    #[cfg(target_os = "linux")]
+    let _ = sd_notify::notify(true, &[NotifyState::Ready]);
+    _rocket.launch().await?;
 
     Ok(())
 }


### PR DESCRIPTION
Currently, services dependent on aw-server.service (e.g. aw-awatcher) start just after its launch.

This patch causes systemd to launch the dependent services only after the rocket server is up an running.

It's aimed to help slow systems to not close the dependent service prematurely due to not being able to connect to the server.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 5031d85fdc04a91adf61c2882dd0ed34de1ccf9f  | 
|--------|--------|

### Summary:
Change systemd service type to `notify` and integrate `sd-notify` to signal readiness in `aw-server`.

**Key points**:
- Change `Type` from `simple` to `notify` in `aw-server.service`.
- Add `sd-notify` dependency in `aw-server/Cargo.toml`.
- Modify `aw-server/src/main.rs` to use `sd_notify::notify` to signal readiness after Rocket server ignition.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->