### PR TITLE
fix(sync): remove bug-causing workaround for spurious small db files (fixes #466)

### DIFF
--- a/aw-sync/src/sync_wrapper.rs
+++ b/aw-sync/src/sync_wrapper.rs
@@ -41,13 +41,6 @@ pub fn pull(host: &str, client: &AwClient) -> Result<(), Box<dyn Error>> {
         })
         .collect::<Vec<_>>();
 
-    // filter out dbs that are smaller than 50kB (workaround for trying to sync empty database
-    // files that are spuriously created somewhere)
-    let dbs = dbs
-        .into_iter()
-        .filter(|entry| entry.metadata().map(|m| m.len() > 50_000).unwrap_or(false))
-        .collect::<Vec<_>>();
-
     // if more than one db, warn and use the largest one
     if dbs.len() > 1 {
         warn!(


### PR DESCRIPTION
Credit to @krzysid in https://github.com/ActivityWatch/aw-server-rust/issues/466#issuecomment-2367467477


<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Removes size-based filtering of database files in `pull()` in `sync_wrapper.rs`, fixing a bug with spurious small files.
> 
>   - **Behavior**:
>     - Removes filtering of database files smaller than 50kB in `pull()` in `sync_wrapper.rs`.
>     - Now processes all `.db` files regardless of size.
>   - **Misc**:
>     - Fixes bug related to spurious small database files during sync.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-server-rust&utm_source=github&utm_medium=referral)<sup> for 952716a5d9700025220a12e1946fe456ceece7b0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->