### PR TITLE
fix(sync): added `client.wait_for_start()` and improve error handling in sync daemon

### DIFF
--- a/aw-client-rust/src/blocking.rs
+++ b/aw-client-rust/src/blocking.rs
@@ -79,4 +79,8 @@ impl AwClient {
     proxy_method!(delete_event, (), bucketname: &str, event_id: i64);
     proxy_method!(get_event_count, i64, bucketname: &str);
     proxy_method!(get_info, aw_models::Info,);
+
+    pub fn wait_for_server(&self) -> Result<(), Box<dyn Error>> {
+        self.client.wait_for_server()
+    }
 }

--- a/aw-client-rust/src/blocking.rs
+++ b/aw-client-rust/src/blocking.rs
@@ -80,7 +80,7 @@ impl AwClient {
     proxy_method!(get_event_count, i64, bucketname: &str);
     proxy_method!(get_info, aw_models::Info,);
 
-    pub fn wait_for_server(&self) -> Result<(), Box<dyn Error>> {
-        self.client.wait_for_server()
+    pub fn wait_for_start(&self) -> Result<(), Box<dyn Error>> {
+        self.client.wait_for_start()
     }
 }

--- a/aw-client-rust/src/lib.rs
+++ b/aw-client-rust/src/lib.rs
@@ -11,6 +11,8 @@ use std::{collections::HashMap, error::Error};
 
 use chrono::{DateTime, Utc};
 use serde_json::{json, Map};
+use std::net::TcpStream;
+use std::time::Duration;
 
 pub use aw_models::{Bucket, BucketMetadata, Event};
 
@@ -220,5 +222,38 @@ impl AwClient {
     pub async fn get_info(&self) -> Result<aw_models::Info, reqwest::Error> {
         let url = format!("{}/api/0/info", self.baseurl);
         self.client.get(url).send().await?.json().await
+    }
+
+    // TODO: make async
+    pub fn wait_for_server(&self) -> Result<(), Box<dyn Error>> {
+        let socket_addrs = self.baseurl.socket_addrs(|| None)?;
+        let socket_addr = socket_addrs.first()
+            .ok_or("Unable to resolve baseurl into socket address")?;
+
+        // Check if server is running with exponential backoff
+        let mut retry_delay = Duration::from_millis(100);
+        let max_wait = Duration::from_secs(10);
+        let mut total_wait = Duration::from_secs(0);
+
+        while total_wait < max_wait {
+            match TcpStream::connect_timeout(socket_addr, retry_delay) {
+                Ok(_) => break,
+                Err(_) => {
+                    std::thread::sleep(retry_delay);
+                    total_wait += retry_delay;
+                    retry_delay *= 2;
+                }
+            }
+        }
+
+        if total_wait >= max_wait {
+            return Err(format!(
+                "Local server {} not running after 10 seconds of retrying",
+                socket_addr
+            )
+            .into());
+        }
+
+        Ok(())
     }
 }

--- a/aw-client-rust/src/lib.rs
+++ b/aw-client-rust/src/lib.rs
@@ -225,9 +225,10 @@ impl AwClient {
     }
 
     // TODO: make async
-    pub fn wait_for_server(&self) -> Result<(), Box<dyn Error>> {
+    pub fn wait_for_start(&self) -> Result<(), Box<dyn Error>> {
         let socket_addrs = self.baseurl.socket_addrs(|| None)?;
-        let socket_addr = socket_addrs.first()
+        let socket_addr = socket_addrs
+            .first()
             .ok_or("Unable to resolve baseurl into socket address")?;
 
         // Check if server is running with exponential backoff

--- a/aw-sync/src/main.rs
+++ b/aw-sync/src/main.rs
@@ -143,6 +143,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         // Start daemon
         Commands::Daemon {} => {
             info!("Starting daemon...");
+            // TODO: log any errors before re-throwing
             daemon(&client)?;
         }
         // Perform basic sync
@@ -208,14 +209,23 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 fn daemon(client: &AwClient) -> Result<(), Box<dyn Error>> {
     loop {
-        info!("Pulling from all hosts");
-        sync_wrapper::pull_all(client)?;
-
-        info!("Pushing local data");
-        sync_wrapper::push(client)?;
+        if let Err(e) = daemon_sync_cycle(client) {
+            error!("Error during sync cycle: {}", e);
+            // Re-throw the error
+            return Err(e);
+        }
 
         info!("Sync pass done, sleeping for 5 minutes");
-
         std::thread::sleep(std::time::Duration::from_secs(300));
     }
+}
+
+fn daemon_sync_cycle(client: &AwClient) -> Result<(), Box<dyn Error>> {
+    info!("Pulling from all hosts");
+    sync_wrapper::pull_all(client)?;
+
+    info!("Pushing local data");
+    sync_wrapper::push(client)?;
+
+    Ok(())
 }

--- a/aw-sync/src/main.rs
+++ b/aw-sync/src/main.rs
@@ -143,7 +143,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         // Start daemon
         Commands::Daemon {} => {
             info!("Starting daemon...");
-            // TODO: log any errors before re-throwing
             daemon(&client)?;
         }
         // Perform basic sync

--- a/aw-sync/src/sync_wrapper.rs
+++ b/aw-sync/src/sync_wrapper.rs
@@ -17,21 +17,21 @@ pub fn pull_all(client: &AwClient) -> Result<(), Box<dyn Error>> {
 fn wait_for_server(socket_addr: &std::net::SocketAddr) -> Result<(), Box<dyn Error>> {
     // Check if server is running with exponential backoff
     let mut retry_delay = Duration::from_millis(100);
-    let max_retry_delay = Duration::from_secs(10);
+    let max_wait = Duration::from_secs(10);
     let mut total_wait = Duration::from_secs(0);
 
-    while total_wait < max_retry_delay {
+    while total_wait < max_wait {
         match TcpStream::connect_timeout(socket_addr, retry_delay) {
             Ok(_) => break,
             Err(_) => {
                 std::thread::sleep(retry_delay);
                 total_wait += retry_delay;
-                retry_delay = std::cmp::min(retry_delay * 2, max_retry_delay);
+                retry_delay *= 2;
             }
         }
     }
 
-    if total_wait >= max_retry_delay {
+    if total_wait >= max_wait {
         return Err(format!(
             "Local server {} not running after 10 seconds of retrying",
             socket_addr

--- a/aw-sync/src/sync_wrapper.rs
+++ b/aw-sync/src/sync_wrapper.rs
@@ -1,7 +1,5 @@
 use std::error::Error;
 use std::fs;
-use std::net::TcpStream;
-use std::time::Duration;
 
 use crate::sync::{sync_run, SyncMode, SyncSpec};
 use aw_client_rust::blocking::AwClient;
@@ -15,7 +13,7 @@ pub fn pull_all(client: &AwClient) -> Result<(), Box<dyn Error>> {
 }
 
 pub fn pull(host: &str, client: &AwClient) -> Result<(), Box<dyn Error>> {
-    client.wait_for_server()?;
+    client.wait_for_start()?;
 
     // Path to the sync folder
     // Sync folder is structured ./{hostname}/{device_id}/test.db


### PR DESCRIPTION
- Added error logging in daemon before re-throwing errors
- Implemented exponential backoff when checking if the server is running
- Addresses issue https://github.com/ActivityWatch/aw-qt/issues/105
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves error handling in `aw-sync` daemon and adds exponential backoff for server connections in `main.rs` and `sync_wrapper.rs`.
> 
>   - **Error Handling**:
>     - Added error logging in `daemon()` in `main.rs` before re-throwing errors.
>     - Introduced `daemon_sync_cycle()` in `main.rs` to encapsulate sync operations and handle errors.
>   - **Server Connection**:
>     - Implemented `wait_for_start()` in `aw-client-rust/src/lib.rs` for exponential backoff when connecting to the server.
>     - Replaced direct server connection check in `pull()` in `sync_wrapper.rs` with `wait_for_start()`.
>   - **Issue Addressed**:
>     - Addresses issue [#105](https://github.com/ActivityWatch/aw-qt/issues/105).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-server-rust&utm_source=github&utm_medium=referral)<sup> for 46b586e152796b997d19d8c00cb29cabf1ef2e91. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->