### PR TITLE
build(deps): bump fern from 0.6.0 to 0.7.0

### DIFF
--- a/aw-server/Cargo.toml
+++ b/aw-server/Cargo.toml
@@ -22,7 +22,7 @@ chrono = { version = "0.4", features = ["serde"] }
 appdirs = "0.2.0"
 lazy_static = "1.4"
 log = "0.4"
-fern = { version = "0.6", features = ["colored"] }
+fern = { version = "0.7", features = ["colored"] }
 toml = "0.8"
 gethostname = "0.4"
 uuid = { version = "1.3", features = ["serde", "v4"] }


### PR DESCRIPTION
Fixes #496
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump `fern` dependency from 0.6.0 to 0.7.0 in `Cargo.toml`.
> 
>   - **Dependencies**:
>     - Bump `fern` version from 0.6.0 to 0.7.0 in `Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-server-rust&utm_source=github&utm_medium=referral)<sup> for 2b66f2da9565403961d38d815707d225f80a97f4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->