### PR TITLE
ci: fix failing code-coverage job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,11 @@ jobs:
     # the link above for those docs.
     # NOTE: actions-rs is unmaintained, using fork with fix for update to node 16
     #       https://github.com/actions-rs/tarpaulin/pull/22
+    - name: Install OpenSSL 1.1
+      run: |
+        wget https://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+        sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+    
     - uses: FreeMasen/tarpaulin-action@9f7e03f06fea8f374c85a95c2ecff6a4d5805845
       with:
         version: "0.22.0"  # not latest, due to error/bug in action (after release artifacts changed name?)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes failing code-coverage job by installing OpenSSL 1.1 in `build-coverage-tarpaulin` job in `build.yml`.
> 
>   - **CI Workflow**:
>     - Adds a step to install OpenSSL 1.1 in `build-coverage-tarpaulin` job in `build.yml`.
>     - Uses `wget` to download and `dpkg` to install `libssl1.1_1.1.1f-1ubuntu2_amd64.deb`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-server-rust&utm_source=github&utm_medium=referral)<sup> for 6eb8e97fab5c150204c9f9cc8d509e30de54ffe2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->