### PR TITLE
feat:add BUILD_SYNC_ONLY variable to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,17 @@ else
 endif
 
 aw-server: set-version aw-webui
+ifeq ($(SKIP_RUST_SERVER),true)
+	@echo "Skipping building aw-server"
+else
 	cargo build $(cargoflag) --bin aw-server
+endif
 
 aw-sync: set-version
 	cargo build $(cargoflag) --bin aw-sync
 
 aw-webui:
-ifeq ($(SKIP_WEBUI),true) # Skip building webui if SKIP_WEBUI is true
+ifneq ($(or $(filter true,$(SKIP_WEBUI)),$(filter true,$(SKIP_RUST_SERVER))),) # Skip building webui if SKIP_WEBUI or SKIP_RUST_SERVER is true
 	@echo "Skipping building webui"
 else
 	make -C ./aw-webui build
@@ -88,7 +92,9 @@ package:
 	rm -rf target/package
 	mkdir -p target/package
 	# Copy binaries
-	cp target/$(targetdir)/aw-server target/package/aw-server-rust
+	ifneq ($(SKIP_RUST_SERVER),true)
+		cp target/$(targetdir)/aw-server target/package/aw-server-rust
+	endif
 	cp target/$(targetdir)/aw-sync target/package/aw-sync
 	# Copy service file
 	cp -f aw-server.service target/package/aw-server.service


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `SKIP_RUST_SERVER` variable to `Makefile` to conditionally skip building and packaging `aw-server`.
> 
>   - **Build Process**:
>     - Introduces `SKIP_RUST_SERVER` variable in `Makefile` to conditionally skip building `aw-server`.
>     - Modifies `aw-webui` build condition to skip if `SKIP_RUST_SERVER` is true.
>   - **Packaging**:
>     - Updates `package` target to conditionally copy `aw-server` binary based on `SKIP_RUST_SERVER`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-server-rust&utm_source=github&utm_medium=referral)<sup> for 5b9c3e94641296024cf2f379f53b3d35f67c1e6f. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->