### PR TITLE
fix(queries): eliminate double-escaping in regex patterns

### DIFF
--- a/aw-client-rust/src/lib.rs
+++ b/aw-client-rust/src/lib.rs
@@ -36,7 +36,7 @@ impl std::fmt::Debug for AwClient {
 }
 
 fn get_hostname() -> String {
-    return gethostname::gethostname().to_string_lossy().to_string();
+    gethostname::gethostname().to_string_lossy().to_string()
 }
 
 impl AwClient {
@@ -122,8 +122,6 @@ impl AwClient {
             .map(|(start, stop)| (start.to_rfc3339(), stop.to_rfc3339()))
             .map(|(start, stop)| format!("{}/{}", start, stop))
             .collect();
-
-        let query_lines: Vec<&str> = query.split('\n').collect();
 
         // Result is a sequence, one element per timeperiod
         self.client


### PR DESCRIPTION
The serialize_classes function was using serde_json serialization which caused regex patterns to be double-escaped (e.g., t\.co became t\\.co, (noticing markdown also does escaping so viewing the raw text is best) breaking pattern matching in ActivityWatch queries.

Core changes:
- Rewrite serialize_classes() to build JSON strings manually instead of using serde_json
- Preserve single-escaped regex patterns for proper matching
- Only include 'ignore_case' field when true (omit when false)
- Only include 'regex' field for non-'none' type categories
- Improve error handling in classes deserialization
- Add optional fields to ClassSetting struct for better compatibility This fixes the core regex pattern matching issues in ActivityWatch canonical queries that were causing incorrect categorization results.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes double-escaping of regex patterns in ActivityWatch queries by manually constructing JSON strings in `serialize_classes()` and improves error handling in `get_classes_from_server()`.
> 
>   - **Behavior**:
>     - `serialize_classes()` in `queries.rs` now manually constructs JSON strings to avoid double-escaping regex patterns.
>     - Preserves single-escaped regex patterns for accurate matching.
>     - Omits 'ignore_case' field when false and 'regex' field for 'none' type categories.
>   - **Error Handling**:
>     - Improved error handling in `get_classes_from_server()` in `classes.rs`.
>   - **Models**:
>     - Added optional fields `id` and `data` to `ClassSetting` struct in `classes.rs` for better compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-server-rust&utm_source=github&utm_medium=referral)<sup> for b705f04fc70971cb8d70b86cf889a9408ccb7eeb. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->