### PR TITLE
fix(android): jstring_to_string function to properly convert Java strings

### DIFF
--- a/aw-server/src/android/mod.rs
+++ b/aw-server/src/android/mod.rs
@@ -83,8 +83,8 @@ pub mod android {
     }
 
     unsafe fn jstring_to_string(env: &JNIEnv, string: JString) -> String {
-        let c_str = CStr::from_ptr(env.get_string(string).expect("invalid string").as_ptr());
-        String::from(c_str.to_str().unwrap())
+        let jstr = env.get_string(string).expect("Failed to get Java string");
+        jstr.into()
     }
 
     unsafe fn string_to_jstring(env: &JNIEnv, string: String) -> jstring {


### PR DESCRIPTION
## Problem
Android app crashes on startup with SIGABRT and `NulError` in SQLite path creation. The Rust native code receives empty strings from Java/Kotlin via JNI.

## Root Cause
The `jstring_to_string` function in `src/android/mod.rs` incorrectly converted JNI strings using `CStr::from_ptr` on raw pointers. This approach doesn't work with JNI's internal string representation, resulting in empty strings being passed to subsequent functions.

## Solution
Fixed the `jstring_to_string` helper function to use the proper `JNIEnv::get_string` API which correctly handles the conversion from Java strings to Rust strings.

## Changes Made
- **Fixed**: `jstring_to_string` function in `src/android/mod.rs`
  - Changed from incorrect `CStr::from_ptr` approach
  - Now uses `env.get_string(string).expect("...").into()` for proper conversion

## Testing
- Verified with aw-android companion app
- App no longer crashes on startup
- Datastore correctly initializes at the specified path
- All JNI string conversions now work correctly

## Impact
This minimal fix resolves the crash while maintaining full backward compatibility. No other changes to the codebase were required.

## Related Issue
Fixes ActivityWatch/aw-android#110 - App crashes on launch on Android 13
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `jstring_to_string` in `mod.rs` for correct Java to Rust string conversion, resolving app crash issue.
> 
>   - **Bug Fix**:
>     - Fix `jstring_to_string` in `mod.rs` to use `JNIEnv::get_string` instead of `CStr::from_ptr` for correct Java to Rust string conversion.
>   - **Testing**:
>     - Verified with aw-android app; no startup crashes.
>     - Datastore initializes correctly; all JNI string conversions work.
>   - **Impact**:
>     - Resolves crash issue, maintains backward compatibility.
>   - **Related Issue**:
>     - Fixes ActivityWatch/aw-android#110.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-server-rust&utm_source=github&utm_medium=referral)<sup> for 0cff97d91f6749c81daf2d8ce3b3f9824eaecd47. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->