### PR TITLE
Update fancy-regex to 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -372,6 +381,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -813,7 +828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -830,12 +845,13 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.12.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7493d4c459da9f84325ad297371a6b2b8a162800873a22e3b6b6512e61d18c05"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
- "bit-set",
- "regex",
+ "bit-set 0.8.0",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2063,7 +2079,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba41b4ee12e29433820b330c8ac41d2f01390be8a8ef8ac59ed2b8edeaa7857e"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
 ]
 
 [[package]]
@@ -2356,7 +2372,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/aw-query/Cargo.toml
+++ b/aw-query/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 plex = "0.3.0"
 log = "0.4"
-fancy-regex = "0.12.0"
+fancy-regex = "0.17.0"
 aw-datastore = { path = "../aw-datastore" }
 aw-models = { path = "../aw-models" }
 aw-transform = { path = "../aw-transform" }

--- a/aw-transform/Cargo.toml
+++ b/aw-transform/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 serde = "1.0"
 url = ">=2.2"
 serde_json = "1.0"
-fancy-regex = "0.12.0"
+fancy-regex = "0.17.0"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 aw-models = { path = "../aw-models" }


### PR DESCRIPTION
https://github.com/fancy-regex/fancy-regex/blob/0.17.0/CHANGELOG.md
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `fancy-regex` to 0.17.0 and adjust related dependencies in `Cargo.toml` and `Cargo.lock`.
> 
>   - **Dependencies**:
>     - Update `fancy-regex` from 0.12.0 to 0.17.0 in `aw-query/Cargo.toml` and `aw-transform/Cargo.toml`.
>     - Update `Cargo.lock` to reflect `fancy-regex` 0.17.0 and its dependencies: `bit-set 0.8.0`, `regex-automata 0.4.9`, `regex-syntax 0.8.5`.
>     - Update `windows-sys` from 0.52.0 to 0.59.0 in `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-server-rust&utm_source=github&utm_medium=referral)<sup> for 4d7e9db0031b9cb02cd45031671fdee1fcdea493. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->