### PR TITLE
Fix/settings persistence on shutdown

### DIFF
--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -294,7 +294,10 @@ impl DatastoreWorker {
                 Err(e) => Err(e),
             },
             Command::SetKeyValue(key, data) => match ds.insert_key_value(tx, &key, &data) {
-                Ok(()) => Ok(Response::Empty()),
+                Ok(()) => {
+                    self.commit = true;
+                    Ok(Response::Empty())
+                }
                 Err(e) => Err(e),
             },
             Command::GetKeyValue(key) => match ds.get_key_value(tx, &key) {
@@ -302,7 +305,10 @@ impl DatastoreWorker {
                 Err(e) => Err(e),
             },
             Command::DeleteKeyValue(key) => match ds.delete_key_value(tx, &key) {
-                Ok(()) => Ok(Response::Empty()),
+                Ok(()) => {
+                    self.commit = true;
+                    Ok(Response::Empty())
+                }
                 Err(e) => Err(e),
             },
             Command::Close() => {


### PR DESCRIPTION
feat(datastore): ensure settings changes are persisted immediately
Problem:
Settings changes (UI preferences, startOfWeek) were being lost on server shutdown because they were waiting for a 15-second background commit timer.

Solution:
Ensure that SetKeyValue and DeleteKeyValue commands set self.commit = true in the datastore worker, forcing immediate persistence.

Steps to Reproduce:
1. Start aw-server-rust.
2. Change a setting (e.g. startOfWeek).
3. Immediately kill the server: pkill -TERM aw-server.
4. Restart and check the setting.

Source:
aw-datastore/src/worker.rs