### PR TITLE
feat(datastore): add opt-in SQLCipher encryption support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "cc",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,6 +1493,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "cc",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "zeroize",
 ]
 
 [[package]]
@@ -3676,6 +3677,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/aw-datastore/Cargo.toml
+++ b/aw-datastore/Cargo.toml
@@ -5,7 +5,15 @@ authors = ["Johan Bjäreholt <johan@bjareho.lt>"]
 edition = "2021"
 
 [features]
-default = [] # no features by default
+default = ["bundled"]
+# Use bundled SQLite (default, no encryption support)
+bundled = ["rusqlite/bundled"]
+# Use bundled SQLCipher for encrypted databases (mutually exclusive with 'bundled')
+# Build with: cargo build --no-default-features --features encryption
+# Requires OpenSSL. Use 'encryption-vendored' to vendor OpenSSL as well.
+encryption = ["rusqlite/bundled-sqlcipher"]
+# Like 'encryption' but also vendors OpenSSL (fully self-contained)
+encryption-vendored = ["rusqlite/bundled-sqlcipher-vendored-openssl"]
 legacy_import_tests = []
 
 [dependencies]
@@ -13,7 +21,7 @@ dirs = "6"
 serde = "1.0"
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
-rusqlite = { version = "0.30", features = ["chrono", "serde_json", "bundled"]  }
+rusqlite = { version = "0.30", features = ["chrono", "serde_json"] }
 mpsc_requests = "0.3"
 log = "0.4"
 

--- a/aw-datastore/Cargo.toml
+++ b/aw-datastore/Cargo.toml
@@ -11,9 +11,9 @@ bundled = ["rusqlite/bundled"]
 # Use bundled SQLCipher for encrypted databases (mutually exclusive with 'bundled')
 # Build with: cargo build --no-default-features --features encryption
 # Requires OpenSSL. Use 'encryption-vendored' to vendor OpenSSL as well.
-encryption = ["rusqlite/bundled-sqlcipher"]
+encryption = ["rusqlite/bundled-sqlcipher", "dep:zeroize"]
 # Like 'encryption' but also vendors OpenSSL (fully self-contained)
-encryption-vendored = ["rusqlite/bundled-sqlcipher-vendored-openssl"]
+encryption-vendored = ["rusqlite/bundled-sqlcipher-vendored-openssl", "dep:zeroize"]
 legacy_import_tests = []
 
 [dependencies]
@@ -24,6 +24,7 @@ chrono = { version = "0.4", features = ["serde"] }
 rusqlite = { version = "0.30", features = ["chrono", "serde_json"] }
 mpsc_requests = "0.3"
 log = "0.4"
+zeroize = { version = "1", optional = true, features = ["alloc"] }
 
 aw-models = { path = "../aw-models" }
 aw-transform = { path = "../aw-transform" }

--- a/aw-datastore/src/lib.rs
+++ b/aw-datastore/src/lib.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate log;
 
+use std::fmt;
+
 #[macro_export]
 macro_rules! json_map {
     { $( $key:literal : $value:expr),* } => {{
@@ -22,7 +24,7 @@ mod worker;
 pub use self::datastore::DatastoreInstance;
 pub use self::worker::Datastore;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum DatastoreMethod {
     Memory(),
     File(String),
@@ -30,6 +32,17 @@ pub enum DatastoreMethod {
     /// `encryption` or `encryption-vendored` feature flags.
     #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
     FileEncrypted(String, String), // (path, key)
+}
+
+impl fmt::Debug for DatastoreMethod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DatastoreMethod::Memory() => write!(f, "Memory()"),
+            DatastoreMethod::File(p) => write!(f, "File({p:?})"),
+            #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+            DatastoreMethod::FileEncrypted(p, _) => write!(f, "FileEncrypted({p:?}, <redacted>)"),
+        }
+    }
 }
 
 /* TODO: Implement this as a proper error */

--- a/aw-datastore/src/lib.rs
+++ b/aw-datastore/src/lib.rs
@@ -26,6 +26,10 @@ pub use self::worker::Datastore;
 pub enum DatastoreMethod {
     Memory(),
     File(String),
+    /// Encrypted SQLite file using SQLCipher. Only available with the
+    /// `encryption` or `encryption-vendored` feature flags.
+    #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+    FileEncrypted(String, String), // (path, key)
 }
 
 /* TODO: Implement this as a proper error */

--- a/aw-datastore/src/lib.rs
+++ b/aw-datastore/src/lib.rs
@@ -32,7 +32,7 @@ pub enum DatastoreMethod {
     /// Encrypted SQLite file using SQLCipher. Only available with the
     /// `encryption` or `encryption-vendored` feature flags.
     #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
-    FileEncrypted(String, String), // (path, key)
+    FileEncrypted(String, zeroize::Zeroizing<String>), // (path, key)
 }
 
 impl fmt::Debug for DatastoreMethod {

--- a/aw-datastore/src/lib.rs
+++ b/aw-datastore/src/lib.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate log;
 
+use std::fmt;
+
 #[macro_export]
 macro_rules! json_map {
     { $( $key:literal : $value:expr),* } => {{
@@ -23,7 +25,7 @@ mod worker;
 pub use self::datastore::DatastoreInstance;
 pub use self::worker::Datastore;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum DatastoreMethod {
     Memory(),
     File(String),
@@ -31,6 +33,17 @@ pub enum DatastoreMethod {
     /// `encryption` or `encryption-vendored` feature flags.
     #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
     FileEncrypted(String, String), // (path, key)
+}
+
+impl fmt::Debug for DatastoreMethod {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DatastoreMethod::Memory() => write!(f, "Memory()"),
+            DatastoreMethod::File(p) => write!(f, "File({p:?})"),
+            #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+            DatastoreMethod::FileEncrypted(p, _) => write!(f, "FileEncrypted({p:?}, <redacted>)"),
+        }
+    }
 }
 
 /* TODO: Implement this as a proper error */

--- a/aw-datastore/src/lib.rs
+++ b/aw-datastore/src/lib.rs
@@ -27,6 +27,10 @@ pub use self::worker::Datastore;
 pub enum DatastoreMethod {
     Memory(),
     File(String),
+    /// Encrypted SQLite file using SQLCipher. Only available with the
+    /// `encryption` or `encryption-vendored` feature flags.
+    #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+    FileEncrypted(String, String), // (path, key)
 }
 
 /* TODO: Implement this as a proper error */

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -125,6 +125,14 @@ impl DatastoreWorker {
             DatastoreMethod::File(path) => {
                 Connection::open(path).expect("Failed to create datastore")
             }
+            #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+            DatastoreMethod::FileEncrypted(path, key) => {
+                let conn = Connection::open(path).expect("Failed to create encrypted datastore");
+                conn.pragma_update(None, "key", key)
+                    .expect("Failed to set SQLCipher encryption key");
+                info!("Opened encrypted database at {}", path);
+                conn
+            }
         };
         let mut ds = DatastoreInstance::new(&conn, true).unwrap();
 
@@ -321,6 +329,16 @@ impl Datastore {
 
     pub fn new_in_memory(legacy_import: bool) -> Self {
         let method = DatastoreMethod::Memory();
+        Datastore::_new_internal(method, legacy_import)
+    }
+
+    /// Create an encrypted datastore using SQLCipher.
+    ///
+    /// Requires the `encryption` or `encryption-vendored` feature flag.
+    /// Build with: `cargo build --no-default-features --features encryption`
+    #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+    pub fn new_encrypted(dbpath: String, key: String, legacy_import: bool) -> Self {
+        let method = DatastoreMethod::FileEncrypted(dbpath, key);
         Datastore::_new_internal(method, legacy_import)
     }
 

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -130,6 +130,12 @@ impl DatastoreWorker {
                 let conn = Connection::open(path).expect("Failed to create encrypted datastore");
                 conn.pragma_update(None, "key", key)
                     .expect("Failed to set SQLCipher encryption key");
+                // PRAGMA key always succeeds even with a wrong passphrase; the
+                // first real SQL query is what fails. Read user_version immediately
+                // to surface an incorrect key as a clear error rather than an
+                // opaque panic later.
+                conn.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                    .expect("Failed to open encrypted database: wrong passphrase or not an encrypted database");
                 info!("Opened encrypted database at {}", path);
                 conn
             }

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -133,7 +133,7 @@ impl DatastoreWorker {
             #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
             DatastoreMethod::FileEncrypted(path, key) => {
                 let conn = Connection::open(path).expect("Failed to create encrypted datastore");
-                conn.pragma_update(None, "key", key)
+                conn.pragma_update(None, "key", key.as_str())
                     .expect("Failed to set SQLCipher encryption key");
                 // PRAGMA key always succeeds even with a wrong passphrase; the
                 // first real SQL query is what fails. Read user_version immediately
@@ -394,7 +394,7 @@ impl Datastore {
     /// Build with: `cargo build --no-default-features --features encryption`
     #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
     pub fn new_encrypted(dbpath: String, key: String, legacy_import: bool) -> Self {
-        let method = DatastoreMethod::FileEncrypted(dbpath, key);
+        let method = DatastoreMethod::FileEncrypted(dbpath, zeroize::Zeroizing::new(key));
         Datastore::_new_internal(method, legacy_import)
     }
 

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -135,6 +135,12 @@ impl DatastoreWorker {
                 let conn = Connection::open(path).expect("Failed to create encrypted datastore");
                 conn.pragma_update(None, "key", key)
                     .expect("Failed to set SQLCipher encryption key");
+                // PRAGMA key always succeeds even with a wrong passphrase; the
+                // first real SQL query is what fails. Read user_version immediately
+                // to surface an incorrect key as a clear error rather than an
+                // opaque panic later.
+                conn.pragma_query_value(None, "user_version", |row| row.get::<_, i64>(0))
+                    .expect("Failed to open encrypted database: wrong passphrase or not an encrypted database");
                 info!("Opened encrypted database at {}", path);
                 conn
             }

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -130,6 +130,14 @@ impl DatastoreWorker {
             DatastoreMethod::File(path) => {
                 Connection::open(path).expect("Failed to create datastore")
             }
+            #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+            DatastoreMethod::FileEncrypted(path, key) => {
+                let conn = Connection::open(path).expect("Failed to create encrypted datastore");
+                conn.pragma_update(None, "key", key)
+                    .expect("Failed to set SQLCipher encryption key");
+                info!("Opened encrypted database at {}", path);
+                conn
+            }
         };
         let mut ds = DatastoreInstance::new(&conn, true).unwrap();
 
@@ -371,6 +379,16 @@ impl Datastore {
 
     pub fn new_in_memory(legacy_import: bool) -> Self {
         let method = DatastoreMethod::Memory();
+        Datastore::_new_internal(method, legacy_import)
+    }
+
+    /// Create an encrypted datastore using SQLCipher.
+    ///
+    /// Requires the `encryption` or `encryption-vendored` feature flag.
+    /// Build with: `cargo build --no-default-features --features encryption`
+    #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+    pub fn new_encrypted(dbpath: String, key: String, legacy_import: bool) -> Self {
+        let method = DatastoreMethod::FileEncrypted(dbpath, key);
         Datastore::_new_internal(method, legacy_import)
     }
 

--- a/aw-datastore/tests/datastore.rs
+++ b/aw-datastore/tests/datastore.rs
@@ -557,6 +557,7 @@ mod datastore_tests {
             };
             let inserted = ds.insert_events(&bucket.id, &[e]).unwrap();
             assert_eq!(inserted.len(), 1);
+            ds.force_commit().unwrap();
             ds.close();
         }
 

--- a/aw-datastore/tests/datastore.rs
+++ b/aw-datastore/tests/datastore.rs
@@ -531,4 +531,46 @@ mod datastore_tests {
             );
         }
     }
+
+    /// Test that an encrypted datastore can be created, written to, and reopened with the same key
+    /// with data intact.
+    #[test]
+    #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+    fn test_encrypted_datastore_roundtrip() {
+        use std::fs;
+        let dir = get_cache_dir().unwrap();
+        let db_path = dir.join("test-encrypted.db").to_str().unwrap().to_string();
+        // Clean up from previous runs
+        let _ = fs::remove_file(&db_path);
+
+        let key = "s3cr3t-p@ssw0rd".to_string();
+
+        // Create and populate encrypted datastore
+        {
+            let ds = Datastore::new_encrypted(db_path.clone(), key.clone(), false);
+            let bucket = create_test_bucket(&ds);
+            let e = Event {
+                id: None,
+                timestamp: Utc::now(),
+                duration: Duration::seconds(1),
+                data: json_map! { "app": "test-encrypted" },
+            };
+            let inserted = ds.insert_events(&bucket.id, &[e]).unwrap();
+            assert_eq!(inserted.len(), 1);
+            ds.close();
+        }
+
+        // Reopen with correct key — data must survive the roundtrip
+        {
+            let ds = Datastore::new_encrypted(db_path.clone(), key.clone(), false);
+            let events = ds
+                .get_events("testid", None, None, None)
+                .expect("should read events from encrypted DB after reopen");
+            assert_eq!(events.len(), 1, "expected 1 event after encrypted reopen");
+            assert_eq!(events[0].data["app"], "test-encrypted");
+            ds.close();
+        }
+
+        let _ = fs::remove_file(&db_path);
+    }
 }

--- a/aw-server/Cargo.toml
+++ b/aw-server/Cargo.toml
@@ -13,6 +13,16 @@ path = "src/lib.rs"
 name = "aw-server"
 path = "src/main.rs"
 
+[features]
+default = ["bundled"]
+# Use bundled SQLite (default, no encryption support)
+bundled = ["aw-datastore/bundled"]
+# Enable SQLCipher encryption support (requires OpenSSL)
+# Build with: cargo build --no-default-features --features encryption
+encryption = ["aw-datastore/encryption"]
+# Enable SQLCipher encryption with vendored OpenSSL (fully self-contained)
+encryption-vendored = ["aw-datastore/encryption-vendored"]
+
 [dependencies]
 rocket = { version = "0.5.0", features = ["json"] }
 rocket_cors = { version = "0.6.0" }
@@ -29,8 +39,7 @@ uuid = { version = "1.3", features = ["serde", "v4"] }
 clap = { version = "4.1", features = ["derive", "cargo"] }
 log-panics = { version = "2", features = ["with-backtrace"]}
 rust-embed = { version = "8.0.0", features = ["interpolate-folder-path", "debug-embed"] }
-
-aw-datastore = { path = "../aw-datastore" }
+aw-datastore = { path = "../aw-datastore", default-features = false }
 aw-models = { path = "../aw-models" }
 aw-transform = { path = "../aw-transform" }
 aw-query = { path = "../aw-query" }

--- a/aw-server/Cargo.toml
+++ b/aw-server/Cargo.toml
@@ -13,6 +13,16 @@ path = "src/lib.rs"
 name = "aw-server"
 path = "src/main.rs"
 
+[features]
+default = ["bundled"]
+# Use bundled SQLite (default, no encryption support)
+bundled = ["aw-datastore/bundled"]
+# Enable SQLCipher encryption support (requires OpenSSL)
+# Build with: cargo build --no-default-features --features encryption
+encryption = ["aw-datastore/encryption"]
+# Enable SQLCipher encryption with vendored OpenSSL (fully self-contained)
+encryption-vendored = ["aw-datastore/encryption-vendored"]
+
 [dependencies]
 rocket = { version = "0.5.0", features = ["json"] }
 rocket_cors = { version = "0.6.0" }
@@ -30,8 +40,7 @@ clap = { version = "4.1", features = ["derive", "cargo"] }
 log-panics = { version = "2", features = ["with-backtrace"]}
 subtle = "2"
 rust-embed = { version = "8.0.0", features = ["interpolate-folder-path", "debug-embed"] }
-
-aw-datastore = { path = "../aw-datastore" }
+aw-datastore = { path = "../aw-datastore", default-features = false }
 aw-models = { path = "../aw-models" }
 aw-transform = { path = "../aw-transform" }
 aw-query = { path = "../aw-query" }

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -57,6 +57,13 @@ struct Opts {
     /// Don't import from aw-server-python if no aw-server-rust db found
     #[clap(long)]
     no_legacy_import: bool,
+
+    /// Encryption key for the database (requires 'encryption' feature).
+    /// Can also be set via the AW_DB_PASSWORD environment variable.
+    /// WARNING: passing a password on the command line may expose it in process listings.
+    #[clap(long, env = "AW_DB_PASSWORD")]
+    #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+    db_password: Option<String>,
 }
 
 #[rocket::main]
@@ -141,10 +148,20 @@ async fn main() -> Result<(), rocket::Error> {
         device_id::get_device_id()
     };
 
+    #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+    let datastore = if let Some(key) = opts.db_password {
+        info!("Using encrypted database (SQLCipher)");
+        aw_datastore::Datastore::new_encrypted(db_path, key, legacy_import)
+    } else {
+        aw_datastore::Datastore::new(db_path, legacy_import)
+    };
+    #[cfg(not(any(feature = "encryption", feature = "encryption-vendored")))]
+    let datastore = aw_datastore::Datastore::new(db_path, legacy_import);
+
     let server_state = endpoints::ServerState {
         // Even if legacy_import is set to true it is disabled on Android so
         // it will not happen there
-        datastore: Mutex::new(aw_datastore::Datastore::new(db_path, legacy_import)),
+        datastore: Mutex::new(datastore),
         asset_resolver: endpoints::AssetResolver::new(asset_path),
         device_id,
     };

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -156,6 +156,16 @@ async fn main() -> Result<(), rocket::Error> {
         aw_datastore::Datastore::new(db_path, legacy_import)
     };
     #[cfg(not(any(feature = "encryption", feature = "encryption-vendored")))]
+    {
+        if std::env::var("AW_DB_PASSWORD").is_ok() {
+            warn!(
+                "AW_DB_PASSWORD is set but this binary was not compiled with encryption support. \
+                 The database will NOT be encrypted. Rebuild with the 'encryption' or \
+                 'encryption-vendored' feature to enable encryption."
+            );
+        }
+    }
+    #[cfg(not(any(feature = "encryption", feature = "encryption-vendored")))]
     let datastore = aw_datastore::Datastore::new(db_path, legacy_import);
 
     let server_state = endpoints::ServerState {

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -160,10 +160,11 @@ async fn main() -> Result<(), rocket::Error> {
     #[cfg(not(any(feature = "encryption", feature = "encryption-vendored")))]
     {
         if std::env::var("AW_DB_PASSWORD").is_ok() {
-            warn!(
+            panic!(
                 "AW_DB_PASSWORD is set but this binary was not compiled with encryption support. \
-                 The database will NOT be encrypted. Rebuild with the 'encryption' or \
-                 'encryption-vendored' feature to enable encryption."
+                 Refusing to start with an unencrypted database when the user requested encryption. \
+                 Rebuild with the 'encryption' or 'encryption-vendored' feature, or unset \
+                 AW_DB_PASSWORD to use an unencrypted database."
             );
         }
     }

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -150,6 +150,8 @@ async fn main() -> Result<(), rocket::Error> {
 
     #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
     let datastore = if let Some(key) = opts.db_password {
+        // Clear the env var immediately so child processes don't inherit the key.
+        std::env::remove_var("AW_DB_PASSWORD");
         info!("Using encrypted database (SQLCipher)");
         aw_datastore::Datastore::new_encrypted(db_path, key, legacy_import)
     } else {

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -164,10 +164,11 @@ async fn main() -> Result<(), rocket::Error> {
     #[cfg(not(any(feature = "encryption", feature = "encryption-vendored")))]
     {
         if std::env::var("AW_DB_PASSWORD").is_ok() {
-            warn!(
+            panic!(
                 "AW_DB_PASSWORD is set but this binary was not compiled with encryption support. \
-                 The database will NOT be encrypted. Rebuild with the 'encryption' or \
-                 'encryption-vendored' feature to enable encryption."
+                 Refusing to start with an unencrypted database when the user requested encryption. \
+                 Rebuild with the 'encryption' or 'encryption-vendored' feature, or unset \
+                 AW_DB_PASSWORD to use an unencrypted database."
             );
         }
     }

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -61,6 +61,13 @@ struct Opts {
     /// Don't import from aw-server-python if no aw-server-rust db found
     #[clap(long)]
     no_legacy_import: bool,
+
+    /// Encryption key for the database (requires 'encryption' feature).
+    /// Can also be set via the AW_DB_PASSWORD environment variable.
+    /// WARNING: passing a password on the command line may expose it in process listings.
+    #[clap(long, env = "AW_DB_PASSWORD")]
+    #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+    db_password: Option<String>,
 }
 
 #[rocket::main]
@@ -145,10 +152,20 @@ async fn main() -> Result<(), rocket::Error> {
         device_id::get_device_id()
     };
 
+    #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+    let datastore = if let Some(key) = opts.db_password {
+        info!("Using encrypted database (SQLCipher)");
+        aw_datastore::Datastore::new_encrypted(db_path, key, legacy_import)
+    } else {
+        aw_datastore::Datastore::new(db_path, legacy_import)
+    };
+    #[cfg(not(any(feature = "encryption", feature = "encryption-vendored")))]
+    let datastore = aw_datastore::Datastore::new(db_path, legacy_import);
+
     let server_state = endpoints::ServerState {
         // Even if legacy_import is set to true it is disabled on Android so
         // it will not happen there
-        datastore: Mutex::new(aw_datastore::Datastore::new(db_path, legacy_import)),
+        datastore: Mutex::new(datastore),
         asset_resolver: endpoints::AssetResolver::new(asset_path),
         device_id,
     };

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -74,6 +74,11 @@ struct Opts {
 async fn main() -> Result<(), rocket::Error> {
     let opts: Opts = Opts::parse();
 
+    // Clear sensitive env vars immediately after parse, before setup_logger can start
+    // background threads (std::env::remove_var is not thread-safe on all platforms).
+    #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
+    std::env::remove_var("AW_DB_PASSWORD");
+
     use std::sync::Mutex;
 
     let mut testing = opts.testing;
@@ -153,13 +158,17 @@ async fn main() -> Result<(), rocket::Error> {
     };
 
     #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
-    let datastore = if let Some(key) = opts.db_password {
-        // Clear the env var immediately so child processes don't inherit the key.
-        std::env::remove_var("AW_DB_PASSWORD");
-        info!("Using encrypted database (SQLCipher)");
-        aw_datastore::Datastore::new_encrypted(db_path, key, legacy_import)
-    } else {
-        aw_datastore::Datastore::new(db_path, legacy_import)
+    let datastore = match opts.db_password {
+        Some(key) if key.is_empty() => {
+            // SQLCipher silently treats PRAGMA key '' as no encryption — reject early so
+            // callers don't end up with a plaintext database while believing it is encrypted.
+            panic!("--db-password / AW_DB_PASSWORD must not be empty; aborting to prevent silent plaintext storage");
+        }
+        Some(key) => {
+            info!("Using encrypted database (SQLCipher)");
+            aw_datastore::Datastore::new_encrypted(db_path, key, legacy_import)
+        }
+        None => aw_datastore::Datastore::new(db_path, legacy_import),
     };
     #[cfg(not(any(feature = "encryption", feature = "encryption-vendored")))]
     {

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -154,6 +154,8 @@ async fn main() -> Result<(), rocket::Error> {
 
     #[cfg(any(feature = "encryption", feature = "encryption-vendored"))]
     let datastore = if let Some(key) = opts.db_password {
+        // Clear the env var immediately so child processes don't inherit the key.
+        std::env::remove_var("AW_DB_PASSWORD");
         info!("Using encrypted database (SQLCipher)");
         aw_datastore::Datastore::new_encrypted(db_path, key, legacy_import)
     } else {

--- a/aw-server/src/main.rs
+++ b/aw-server/src/main.rs
@@ -160,6 +160,16 @@ async fn main() -> Result<(), rocket::Error> {
         aw_datastore::Datastore::new(db_path, legacy_import)
     };
     #[cfg(not(any(feature = "encryption", feature = "encryption-vendored")))]
+    {
+        if std::env::var("AW_DB_PASSWORD").is_ok() {
+            warn!(
+                "AW_DB_PASSWORD is set but this binary was not compiled with encryption support. \
+                 The database will NOT be encrypted. Rebuild with the 'encryption' or \
+                 'encryption-vendored' feature to enable encryption."
+            );
+        }
+    }
+    #[cfg(not(any(feature = "encryption", feature = "encryption-vendored")))]
     let datastore = aw_datastore::Datastore::new(db_path, legacy_import);
 
     let server_state = endpoints::ServerState {


### PR DESCRIPTION
## Summary

Implements encrypted database storage at rest using [SQLCipher](https://github.com/sqlcipher/sqlcipher) (via the `rusqlite/bundled-sqlcipher` feature). Data remains fully encrypted on disk; decryption only happens in-process after the key is supplied.

Closes #435

## Design

SQLCipher is a drop-in replacement for SQLite that transparently encrypts every database page. All existing schema/migration code works unchanged — only the connection-open step gains an extra `PRAGMA key` call.

This is implemented as a **Cargo feature flag** so the default binary stays unchanged. Users who want encryption build with:

```sh
cargo build --no-default-features --features encryption
# or, for a fully self-contained binary that also vendors OpenSSL:
cargo build --no-default-features --features encryption-vendored
```

### Feature flags

| Feature | SQLite backend | OpenSSL |
|---|---|---|
| `bundled` *(default)* | bundled plain SQLite | — |
| `encryption` | bundled SQLCipher | system OpenSSL required |
| `encryption-vendored` | bundled SQLCipher | vendored via openssl-sys |

`bundled` and `encryption*` are **mutually exclusive** (libsqlite3-sys enforces this). Use `--no-default-features` when enabling encryption.

### API changes

**aw-datastore**:
- New `DatastoreMethod::FileEncrypted(path, key)` variant (cfg-gated)
- New `Datastore::new_encrypted(dbpath, key, legacy_import)` constructor

**aw-server**:
- New `--db-password <KEY>` CLI flag (also readable from `AW_DB_PASSWORD` env var)

### Usage

```sh
# Start server with encryption (key via flag)
aw-server --db-password "my-secret-passphrase"

# Start server with encryption (key via env var — preferred for scripts)
export AW_DB_PASSWORD="my-secret-passphrase"
aw-server
```

> ⚠️ **Warning**: The key is stored in-memory for the lifetime of the process. Passing it on the CLI exposes it in `ps` output. Prefer `AW_DB_PASSWORD` in production.

## Changes

- `aw-datastore/Cargo.toml` — restructure rusqlite features; add `encryption` and `encryption-vendored`
- `aw-datastore/src/lib.rs` — add `DatastoreMethod::FileEncrypted` variant
- `aw-datastore/src/worker.rs` — open encrypted connection with `PRAGMA key`; add `Datastore::new_encrypted()`
- `aw-server/Cargo.toml` — forward encryption features from aw-datastore; change `aw-datastore` dep to `default-features = false`
- `aw-server/src/main.rs` — `--db-password` / `AW_DB_PASSWORD` option; select `new_encrypted()` when key is present
- `aw-datastore/tests/datastore.rs` — `test_encrypted_datastore_roundtrip`: creates encrypted DB, writes events, closes, reopens with same key, verifies data is intact

## Test plan

- [x] Default build (`cargo check`) passes with no errors
- [ ] Encryption build: `cargo test --no-default-features --features encryption -- test_encrypted_datastore_roundtrip` (requires OpenSSL)
- [ ] Manual smoke test: start `aw-server --db-password foo`, send heartbeats, stop, verify `file aw-server-rust.db` shows "SQLite database" is no longer readable as plain SQLite