### PR TITLE
fix(aw-client-rust): fail on non-2xx responses

### DIFF
--- a/aw-client-rust/README.md
+++ b/aw-client-rust/README.md
@@ -3,4 +3,5 @@ aw-client-rust
 
 WIP: aw-client implementation in Rust
 
-TODO: Better error handling (requests currently never fail?)
+Non-2xx HTTP responses are surfaced as `reqwest` status errors in both the async
+and blocking clients.

--- a/aw-client-rust/src/lib.rs
+++ b/aw-client-rust/src/lib.rs
@@ -40,6 +40,12 @@ fn get_hostname() -> String {
     gethostname::gethostname().to_string_lossy().to_string()
 }
 
+async fn send_for_status(
+    request: reqwest::RequestBuilder,
+) -> Result<reqwest::Response, reqwest::Error> {
+    request.send().await?.error_for_status()
+}
+
 fn build_client(api_key: Option<String>) -> Result<reqwest::Client, Box<dyn Error>> {
     let mut headers = HeaderMap::new();
     if let Some(api_key) = api_key {
@@ -83,25 +89,18 @@ impl AwClient {
 
     pub async fn get_bucket(&self, bucketname: &str) -> Result<Bucket, reqwest::Error> {
         let url = format!("{}api/0/buckets/{}", self.baseurl, bucketname);
-        let bucket = self
-            .client
-            .get(url)
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await?;
+        let bucket = send_for_status(self.client.get(url)).await?.json().await?;
         Ok(bucket)
     }
 
     pub async fn get_buckets(&self) -> Result<HashMap<String, Bucket>, reqwest::Error> {
         let url = format!("{}api/0/buckets/", self.baseurl);
-        self.client.get(url).send().await?.json().await
+        send_for_status(self.client.get(url)).await?.json().await
     }
 
     pub async fn create_bucket(&self, bucket: &Bucket) -> Result<(), reqwest::Error> {
         let url = format!("{}api/0/buckets/{}", self.baseurl, bucket.id);
-        self.client.post(url).json(bucket).send().await?;
+        send_for_status(self.client.post(url).json(bucket)).await?;
         Ok(())
     }
 
@@ -127,7 +126,7 @@ impl AwClient {
 
     pub async fn delete_bucket(&self, bucketname: &str) -> Result<(), reqwest::Error> {
         let url = format!("{}api/0/buckets/{}", self.baseurl, bucketname);
-        self.client.delete(url).send().await?;
+        send_for_status(self.client.delete(url)).await?;
         Ok(())
     }
 
@@ -154,6 +153,7 @@ impl AwClient {
             }))
             .send()
             .await?
+            .error_for_status()?
             .json()
             .await
     }
@@ -183,7 +183,7 @@ impl AwClient {
             url.query_pairs_mut()
                 .append_pair("limit", s.to_string().as_str());
         };
-        self.client.get(url).send().await?.json().await
+        send_for_status(self.client.get(url)).await?.json().await
     }
 
     pub async fn insert_event(
@@ -193,7 +193,7 @@ impl AwClient {
     ) -> Result<(), reqwest::Error> {
         let url = format!("{}api/0/buckets/{}/events", self.baseurl, bucketname);
         let eventlist = vec![event.clone()];
-        self.client.post(url).json(&eventlist).send().await?;
+        send_for_status(self.client.post(url).json(&eventlist)).await?;
         Ok(())
     }
 
@@ -203,7 +203,7 @@ impl AwClient {
         events: Vec<Event>,
     ) -> Result<(), reqwest::Error> {
         let url = format!("{}api/0/buckets/{}/events", self.baseurl, bucketname);
-        self.client.post(url).json(&events).send().await?;
+        send_for_status(self.client.post(url).json(&events)).await?;
         Ok(())
     }
 
@@ -217,7 +217,7 @@ impl AwClient {
             "{}api/0/buckets/{}/heartbeat?pulsetime={}",
             self.baseurl, bucketname, pulsetime
         );
-        self.client.post(url).json(&event).send().await?;
+        send_for_status(self.client.post(url).json(&event)).await?;
         Ok(())
     }
 
@@ -230,20 +230,13 @@ impl AwClient {
             "{}api/0/buckets/{}/events/{}",
             self.baseurl, bucketname, event_id
         );
-        self.client.delete(url).send().await?;
+        send_for_status(self.client.delete(url)).await?;
         Ok(())
     }
 
     pub async fn get_event_count(&self, bucketname: &str) -> Result<i64, reqwest::Error> {
         let url = format!("{}api/0/buckets/{}/events/count", self.baseurl, bucketname);
-        let res = self
-            .client
-            .get(url)
-            .send()
-            .await?
-            .error_for_status()?
-            .text()
-            .await?;
+        let res = send_for_status(self.client.get(url)).await?.text().await?;
         let count: i64 = match res.trim().parse() {
             Ok(count) => count,
             Err(err) => panic!("could not parse get_event_count response: {err:?}"),
@@ -253,17 +246,17 @@ impl AwClient {
 
     pub async fn get_info(&self) -> Result<aw_models::Info, reqwest::Error> {
         let url = format!("{}api/0/info", self.baseurl);
-        self.client.get(url).send().await?.json().await
+        send_for_status(self.client.get(url)).await?.json().await
     }
 
     pub async fn get_setting(&self, setting: &str) -> Result<serde_json::Value, reqwest::Error> {
         let url = format!("{}api/0/settings/{}", self.baseurl, setting);
-        self.client.get(url).send().await?.json().await
+        send_for_status(self.client.get(url)).await?.json().await
     }
 
     pub async fn get_settings(&self) -> Result<aw_models::Settings, reqwest::Error> {
         let url = format!("{}api/0/settings", self.baseurl);
-        self.client.get(url).send().await?.json().await
+        send_for_status(self.client.get(url)).await?.json().await
     }
 
     // TODO: make async

--- a/aw-client-rust/src/lib.rs
+++ b/aw-client-rust/src/lib.rs
@@ -145,17 +145,13 @@ impl AwClient {
             .collect();
 
         // Result is a sequence, one element per timeperiod
-        self.client
-            .post(url)
-            .json(&json!({
-                "query": query.split('\n').collect::<Vec<&str>>(),
-                "timeperiods": timeperiods_str,
-            }))
-            .send()
-            .await?
-            .error_for_status()?
-            .json()
-            .await
+        send_for_status(self.client.post(url).json(&json!({
+            "query": query.split('\n').collect::<Vec<&str>>(),
+            "timeperiods": timeperiods_str,
+        })))
+        .await?
+        .json()
+        .await
     }
 
     pub async fn get_events(

--- a/aw-client-rust/tests/test.rs
+++ b/aw-client-rust/tests/test.rs
@@ -2,6 +2,7 @@ extern crate aw_client_rust;
 extern crate aw_datastore;
 extern crate aw_server;
 extern crate chrono;
+extern crate reqwest;
 extern crate rocket;
 extern crate serde_json;
 extern crate tokio_test;
@@ -9,8 +10,10 @@ extern crate tokio_test;
 #[cfg(test)]
 mod test {
     use aw_client_rust::blocking::AwClient;
+    use aw_client_rust::AwClient as AsyncAwClient;
     use aw_client_rust::Event;
     use chrono::{DateTime, Duration, Utc};
+    use reqwest::StatusCode;
     use serde_json::Map;
     use std::cell::RefCell;
     use std::fs;
@@ -92,6 +95,10 @@ mod test {
     // Keep the listener alive until the server binds — prevents TOCTOU race in reserve_port
     thread_local! {
         static RESERVED_PORT: RefCell<Option<TcpListener>> = RefCell::new(None);
+    }
+
+    fn assert_status(err: reqwest::Error, status: StatusCode) {
+        assert_eq!(err.status(), Some(status));
     }
 
     fn wait_for_server(timeout_s: u32, client: &AwClient) {
@@ -259,6 +266,36 @@ RETURN = events;",
         assert_eq!(count, 0);
 
         client.delete_bucket(&bucketname).unwrap();
+
+        shutdown_handler.notify();
+    }
+
+    #[test]
+    fn test_non_2xx_responses_return_status_errors() {
+        let clientname = "aw-client-rust-status-test";
+        let async_clientname = "aw-client-rust-status-test-async";
+        let port = reserve_port();
+        let (client, async_client) = {
+            let _guard = ENV_LOCK.lock().unwrap();
+            (
+                AwClient::new("127.0.0.1", port, clientname).expect("Client creation failed"),
+                AsyncAwClient::new("127.0.0.1", port, async_clientname)
+                    .expect("Client creation failed"),
+            )
+        };
+
+        RESERVED_PORT.with(|cell| *cell.borrow_mut() = None);
+        let shutdown_handler = setup_testserver(port, None);
+
+        wait_for_server(20, &client);
+
+        let missing_bucket = format!("aw-client-rust-missing_{}", client.hostname);
+        let delete_err = client.delete_bucket(&missing_bucket).unwrap_err();
+        assert_status(delete_err, StatusCode::NOT_FOUND);
+
+        let get_events_err =
+            block_on(async_client.get_events(&missing_bucket, None, None, None)).unwrap_err();
+        assert_status(get_events_err, StatusCode::NOT_FOUND);
 
         shutdown_handler.notify();
     }


### PR DESCRIPTION
## Summary
- fail fast on non-2xx responses before JSON decoding or returning `Ok(())`
- cover both blocking and async client paths with regression tests
- replace the stale README note that claimed requests never failed

## Testing
- cargo test --locked -p aw-client-rust