### PR TITLE
fix(aw-client-rust): fail on non-2xx responses

### DIFF
--- a/aw-client-rust/README.md
+++ b/aw-client-rust/README.md
@@ -2,5 +2,3 @@ aw-client-rust
 ==============
 
 WIP: aw-client implementation in Rust
-
-TODO: Better error handling (requests currently never fail?)

--- a/aw-client-rust/src/lib.rs
+++ b/aw-client-rust/src/lib.rs
@@ -55,6 +55,12 @@ fn build_client(api_key: Option<String>) -> Result<reqwest::Client, Box<dyn Erro
 }
 
 impl AwClient {
+    async fn send_success(
+        request: reqwest::RequestBuilder,
+    ) -> Result<reqwest::Response, reqwest::Error> {
+        request.send().await?.error_for_status()
+    }
+
     pub fn new(host: &str, port: u16, name: &str) -> Result<AwClient, Box<dyn Error>> {
         Self::new_with_api_key(host, port, name, None)
     }
@@ -83,12 +89,8 @@ impl AwClient {
 
     pub async fn get_bucket(&self, bucketname: &str) -> Result<Bucket, reqwest::Error> {
         let url = format!("{}api/0/buckets/{}", self.baseurl, bucketname);
-        let bucket = self
-            .client
-            .get(url)
-            .send()
+        let bucket = Self::send_success(self.client.get(url))
             .await?
-            .error_for_status()?
             .json()
             .await?;
         Ok(bucket)
@@ -96,12 +98,12 @@ impl AwClient {
 
     pub async fn get_buckets(&self) -> Result<HashMap<String, Bucket>, reqwest::Error> {
         let url = format!("{}api/0/buckets/", self.baseurl);
-        self.client.get(url).send().await?.json().await
+        Self::send_success(self.client.get(url)).await?.json().await
     }
 
     pub async fn create_bucket(&self, bucket: &Bucket) -> Result<(), reqwest::Error> {
         let url = format!("{}api/0/buckets/{}", self.baseurl, bucket.id);
-        self.client.post(url).json(bucket).send().await?;
+        Self::send_success(self.client.post(url).json(bucket)).await?;
         Ok(())
     }
 
@@ -127,7 +129,7 @@ impl AwClient {
 
     pub async fn delete_bucket(&self, bucketname: &str) -> Result<(), reqwest::Error> {
         let url = format!("{}api/0/buckets/{}", self.baseurl, bucketname);
-        self.client.delete(url).send().await?;
+        Self::send_success(self.client.delete(url)).await?;
         Ok(())
     }
 
@@ -146,16 +148,13 @@ impl AwClient {
             .collect();
 
         // Result is a sequence, one element per timeperiod
-        self.client
-            .post(url)
-            .json(&json!({
-                "query": query.split('\n').collect::<Vec<&str>>(),
-                "timeperiods": timeperiods_str,
-            }))
-            .send()
-            .await?
-            .json()
-            .await
+        Self::send_success(self.client.post(url).json(&json!({
+            "query": query.split('\n').collect::<Vec<&str>>(),
+            "timeperiods": timeperiods_str,
+        })))
+        .await?
+        .json()
+        .await
     }
 
     pub async fn get_events(
@@ -183,7 +182,7 @@ impl AwClient {
             url.query_pairs_mut()
                 .append_pair("limit", s.to_string().as_str());
         };
-        self.client.get(url).send().await?.json().await
+        Self::send_success(self.client.get(url)).await?.json().await
     }
 
     pub async fn insert_event(
@@ -193,7 +192,7 @@ impl AwClient {
     ) -> Result<(), reqwest::Error> {
         let url = format!("{}api/0/buckets/{}/events", self.baseurl, bucketname);
         let eventlist = vec![event.clone()];
-        self.client.post(url).json(&eventlist).send().await?;
+        Self::send_success(self.client.post(url).json(&eventlist)).await?;
         Ok(())
     }
 
@@ -203,7 +202,7 @@ impl AwClient {
         events: Vec<Event>,
     ) -> Result<(), reqwest::Error> {
         let url = format!("{}api/0/buckets/{}/events", self.baseurl, bucketname);
-        self.client.post(url).json(&events).send().await?;
+        Self::send_success(self.client.post(url).json(&events)).await?;
         Ok(())
     }
 
@@ -217,7 +216,7 @@ impl AwClient {
             "{}api/0/buckets/{}/heartbeat?pulsetime={}",
             self.baseurl, bucketname, pulsetime
         );
-        self.client.post(url).json(&event).send().await?;
+        Self::send_success(self.client.post(url).json(&event)).await?;
         Ok(())
     }
 
@@ -230,18 +229,14 @@ impl AwClient {
             "{}api/0/buckets/{}/events/{}",
             self.baseurl, bucketname, event_id
         );
-        self.client.delete(url).send().await?;
+        Self::send_success(self.client.delete(url)).await?;
         Ok(())
     }
 
     pub async fn get_event_count(&self, bucketname: &str) -> Result<i64, reqwest::Error> {
         let url = format!("{}api/0/buckets/{}/events/count", self.baseurl, bucketname);
-        let res = self
-            .client
-            .get(url)
-            .send()
+        let res = Self::send_success(self.client.get(url))
             .await?
-            .error_for_status()?
             .text()
             .await?;
         let count: i64 = match res.trim().parse() {
@@ -253,17 +248,17 @@ impl AwClient {
 
     pub async fn get_info(&self) -> Result<aw_models::Info, reqwest::Error> {
         let url = format!("{}api/0/info", self.baseurl);
-        self.client.get(url).send().await?.json().await
+        Self::send_success(self.client.get(url)).await?.json().await
     }
 
     pub async fn get_setting(&self, setting: &str) -> Result<serde_json::Value, reqwest::Error> {
         let url = format!("{}api/0/settings/{}", self.baseurl, setting);
-        self.client.get(url).send().await?.json().await
+        Self::send_success(self.client.get(url)).await?.json().await
     }
 
     pub async fn get_settings(&self) -> Result<aw_models::Settings, reqwest::Error> {
         let url = format!("{}api/0/settings", self.baseurl);
-        self.client.get(url).send().await?.json().await
+        Self::send_success(self.client.get(url)).await?.json().await
     }
 
     // TODO: make async

--- a/aw-client-rust/tests/status_errors.rs
+++ b/aw-client-rust/tests/status_errors.rs
@@ -1,0 +1,107 @@
+use std::future::Future;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::thread;
+
+use aw_client_rust::blocking;
+use aw_client_rust::AwClient;
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build test runtime")
+        .block_on(future)
+}
+
+struct MockResponse {
+    status_line: &'static str,
+    content_type: &'static str,
+    body: &'static str,
+}
+
+fn spawn_mock_server(responses: Vec<MockResponse>) -> (u16, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind mock server");
+    let port = listener.local_addr().expect("mock server addr").port();
+    let handle = thread::spawn(move || {
+        for response in responses {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut buffer = [0_u8; 4096];
+            let _ = stream.read(&mut buffer).expect("read request");
+            let body = response.body.as_bytes();
+            write!(
+                stream,
+                "HTTP/1.1 {}\r\nContent-Length: {}\r\nContent-Type: {}\r\nConnection: close\r\n\r\n{}",
+                response.status_line,
+                body.len(),
+                response.content_type,
+                response.body
+            )
+            .expect("write response");
+            stream.flush().expect("flush response");
+        }
+    });
+    (port, handle)
+}
+
+#[test]
+fn async_client_rejects_non_success_statuses() {
+    let (port, handle) = spawn_mock_server(vec![
+        MockResponse {
+            status_line: "500 Internal Server Error",
+            content_type: "application/json",
+            body: "{}",
+        },
+        MockResponse {
+            status_line: "409 Conflict",
+            content_type: "text/plain",
+            body: "",
+        },
+    ]);
+    let client = AwClient::new("127.0.0.1", port, "aw-client-rust-test").expect("create client");
+
+    let err = block_on(client.get_buckets()).expect_err("500 response must fail");
+    assert_eq!(
+        err.status(),
+        Some(reqwest::StatusCode::INTERNAL_SERVER_ERROR)
+    );
+
+    let err = block_on(client.create_bucket_simple("bucket", "type"))
+        .expect_err("409 response must fail");
+    assert_eq!(err.status(), Some(reqwest::StatusCode::CONFLICT));
+
+    handle.join().expect("join mock server");
+}
+
+#[test]
+fn blocking_client_rejects_non_success_statuses() {
+    let (port, handle) = spawn_mock_server(vec![
+        MockResponse {
+            status_line: "500 Internal Server Error",
+            content_type: "application/json",
+            body: "{}",
+        },
+        MockResponse {
+            status_line: "409 Conflict",
+            content_type: "text/plain",
+            body: "",
+        },
+    ]);
+    let client =
+        blocking::AwClient::new("127.0.0.1", port, "aw-client-rust-test").expect("create client");
+
+    let err = client
+        .get_buckets()
+        .expect_err("500 response must fail for blocking client");
+    assert_eq!(
+        err.status(),
+        Some(reqwest::StatusCode::INTERNAL_SERVER_ERROR)
+    );
+
+    let err = client
+        .create_bucket_simple("bucket", "type")
+        .expect_err("409 response must fail for blocking client");
+    assert_eq!(err.status(), Some(reqwest::StatusCode::CONFLICT));
+
+    handle.join().expect("join mock server");
+}

--- a/aw-client-rust/tests/status_errors.rs
+++ b/aw-client-rust/tests/status_errors.rs
@@ -47,7 +47,9 @@ fn drain_request(stream: &mut impl Read) {
     }
     if content_length > 0 {
         let mut body_buf = vec![0_u8; content_length];
-        reader.read_exact(&mut body_buf).expect("drain request body");
+        reader
+            .read_exact(&mut body_buf)
+            .expect("drain request body");
     }
 }
 

--- a/aw-client-rust/tests/status_errors.rs
+++ b/aw-client-rust/tests/status_errors.rs
@@ -1,5 +1,5 @@
 use std::future::Future;
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpListener;
 use std::thread;
 
@@ -20,14 +20,44 @@ struct MockResponse {
     body: &'static str,
 }
 
+/// Drain the HTTP request fully before responding.
+///
+/// Parses Content-Length from headers so POST body data (which may arrive
+/// in a separate TCP segment) is consumed before the mock writes its
+/// response. Without this, reqwest may see a broken pipe on loopback if
+/// the response arrives before the body finishes sending.
+fn drain_request(stream: &mut impl Read) {
+    let mut reader = BufReader::new(stream);
+    let mut content_length = 0_usize;
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).expect("read request line");
+        if n == 0 {
+            break;
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            // End of headers; body follows if Content-Length > 0
+            break;
+        }
+        if let Some(val) = trimmed.strip_prefix("Content-Length:") {
+            content_length = val.trim().parse().unwrap_or(0);
+        }
+    }
+    if content_length > 0 {
+        let mut body_buf = vec![0_u8; content_length];
+        reader.read_exact(&mut body_buf).expect("drain request body");
+    }
+}
+
 fn spawn_mock_server(responses: Vec<MockResponse>) -> (u16, thread::JoinHandle<()>) {
     let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind mock server");
     let port = listener.local_addr().expect("mock server addr").port();
     let handle = thread::spawn(move || {
         for response in responses {
             let (mut stream, _) = listener.accept().expect("accept request");
-            let mut buffer = [0_u8; 4096];
-            let _ = stream.read(&mut buffer).expect("read request");
+            drain_request(&mut stream);
             let body = response.body.as_bytes();
             write!(
                 stream,


### PR DESCRIPTION
## Summary
- reject non-success HTTP responses across aw-client-rust request paths before returning success or decoding JSON
- add focused regression tests for async and blocking clients using a tiny mock HTTP server
- drop the stale README note claiming requests never fail

## Verification
- cargo test -p aw-client-rust
