### PR TITLE
fix(android): load embedded server config

### DIFF
--- a/aw-server/src/android/mod.rs
+++ b/aw-server/src/android/mod.rs
@@ -38,7 +38,6 @@ pub mod android {
     use std::path::PathBuf;
     use std::sync::Mutex;
 
-    use crate::config::AWConfig;
     use crate::endpoints;
     use crate::endpoints::ServerState;
     use aw_client_rust::blocking::AwClient;
@@ -127,7 +126,7 @@ pub mod android {
             };
             info!("Using server_state:: device_id: {}", server_state.device_id);
 
-            let mut server_config: AWConfig = AWConfig::default();
+            let mut server_config = crate::config::create_config(false);
             server_config.port = 5600;
 
             endpoints::build_rocket(server_state, server_config)

--- a/aw-server/src/android/mod.rs
+++ b/aw-server/src/android/mod.rs
@@ -126,7 +126,7 @@ pub mod android {
             };
             info!("Using server_state:: device_id: {}", server_state.device_id);
 
-            let mut server_config = crate::config::create_config(false);
+            let mut server_config = crate::config::create_config(false, None);
             server_config.port = 5600;
 
             endpoints::build_rocket(server_state, server_config)

--- a/aw-server/src/device_id.rs
+++ b/aw-server/src/device_id.rs
@@ -6,7 +6,7 @@ use crate::dirs;
 
 /// Retrieves the device ID, if none exists it generates one (using UUID v4)
 pub fn get_device_id() -> String {
-    // I chose get_data_dir over get_config_dir since the latter isn't yet supported on Android.
+    // Device IDs are mutable app data, so they live next to the datastore rather than config.
     let mut path = dirs::get_data_dir().unwrap();
     path.push("device_id");
     if path.exists() {

--- a/aw-server/src/dirs.rs
+++ b/aw-server/src/dirs.rs
@@ -25,7 +25,7 @@ pub fn get_config_dir() -> Result<PathBuf, ()> {
 
 #[cfg(target_os = "android")]
 pub fn get_config_dir() -> Result<PathBuf, ()> {
-    panic!("not implemented on Android");
+    Ok(ANDROID_DATA_DIR.lock().unwrap().to_path_buf())
 }
 
 #[cfg(not(target_os = "android"))]


### PR DESCRIPTION
## Summary
- load the embedded Android server config with `create_config(false)` instead of starting from `AWConfig::default()`
- make Android `get_config_dir()` return the app data dir so config-backed auth state can actually exist on-device
- keep device IDs in app data with a corrected comment explaining why

## Why
Android auth is still blocked before the `aw-android` WebView handoff step: the embedded `aw-server-rust` path currently bypasses `config.toml`, so `[auth].api_key` cannot be loaded or persisted on Android at all. This patch fixes that prerequisite and unblocks `ActivityWatch/aw-android#145`.

## Testing
- `cargo test -p aw-server`

## Notes
I could not run an Android-target build in this environment because only the Linux host target is installed here, so the Android-specific validation still needs device/SDK coverage on the `aw-android` side.
