### PR TITLE
fix(android): make compile-android.sh cwd-safe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Verify Android build script cwd handling
+      run: bash ./scripts/test-compile-android-cwd.sh
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@stable
     - name: Cache cargo build

--- a/compile-android.sh
+++ b/compile-android.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 
 set -e
+SCRIPT_DIR="$(
+    unset CDPATH
+    cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
+    pwd
+)"
+cd "$SCRIPT_DIR"
+
 platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
 # if args, use them to select targets (x86_64, arm64, etc)
 if [ $# -gt 0 ]; then
-    targets="$@"
+    targets="$*"
 else
     # otherwise, default to all targets
     targets="arm64 x86_64 x86 arm"
@@ -13,11 +20,12 @@ fi
 
 ORIG_PATH="$PATH"
 ORIG_RUSTFLAGS="$RUSTFLAGS"
+release_args=()
 
 if [ -z "$ANDROID_NDK_HOME" ]; then
-    if [ -d `pwd`/"NDK" ]; then
+    if [ -d "$SCRIPT_DIR"/NDK ]; then
         echo "Found NDK folder in root, using."
-        ANDROID_NDK_HOME=`pwd`/NDK
+        ANDROID_NDK_HOME="$SCRIPT_DIR"/NDK
     else
         # NOTE: I had some issues with this and cargo that magically resolved themselves when I made the path absolute.
         echo "Environment variable ANDROID_NDK_HOME not set, please set to location of Android NDK."
@@ -28,6 +36,7 @@ export ANDROID_NDK_HOME
 
 if [ "$RELEASE" = "true" ]; then
     echo "Building in release mode... (slow)";
+    release_args+=(--release)
 else
     echo "Building in debug mode... (fast)"
     RELEASE=false;
@@ -43,13 +52,20 @@ for archtargetstr in \
     'x86 i686-linux-android' \
     'arm armv7-linux-androideabi' \
 ; do
-    arch=$(echo $archtargetstr | cut -d " " -f 1)
-    target=$(echo $archtargetstr | cut -d " " -f 2)
-    target_underscore=$(echo $target | sed 's/-/_/g')
+    arch="$(echo "$archtargetstr" | cut -d " " -f 1)"
+    target="$(echo "$archtargetstr" | cut -d " " -f 2)"
+    target_underscore="${target//-/_}"
 
-    echo ARCH $arch
-    echo TARGET $target
-    if ! echo "$targets" | grep -q "$arch"; then
+    echo ARCH "$arch"
+    echo TARGET "$target"
+    selected=false
+    for requested_arch in $targets; do
+        if [ "$requested_arch" = "$arch" ]; then
+            selected=true
+            break
+        fi
+    done
+    if [ "$selected" != "true" ]; then
         echo "Skipping $arch..."
         continue
     fi
@@ -72,10 +88,11 @@ for archtargetstr in \
 
     # Needed for runtime error: https://github.com/termux/termux-packages/issues/8029
     #   java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "__extenddftf2"
-    export RUSTFLAGS+=" -C link-arg=$($NDK_ARCH_DIR/${target}-clang -print-libgcc-file-name)"
+    libgcc_path="$("$NDK_ARCH_DIR/${target}-clang" -print-libgcc-file-name)"
+    export RUSTFLAGS+=" -C link-arg=$libgcc_path"
     # Align to 16KB for Android 15 compatibility
     export RUSTFLAGS+=" -C link-arg=-z -C link-arg=max-page-size=16384"
-    echo RUSTFLAGS=$RUSTFLAGS
+    echo RUSTFLAGS="$RUSTFLAGS"
 
     # fix armv7 -> arm
     if [ "$arch" = "arm" ]; then
@@ -92,12 +109,12 @@ for archtargetstr in \
 
     # People suggest to use this, but ime it needs all the same workarounds anyway :shrug:
     #cargo ndk build -p aw-server --target $target --lib $($RELEASE && echo '--release')
-    
+
     # Build aw-server
     echo "Building aw-server for $arch..."
-    cargo build -p aw-server --target $target --lib $($RELEASE && echo '--release')
-    
+    cargo build -p aw-server --target "$target" --lib "${release_args[@]}"
+
     # Build aw-sync (without cli feature for Android)
     echo "Building aw-sync for $arch..."
-    cargo build -p aw-sync --target $target --lib --no-default-features $($RELEASE && echo '--release')
+    cargo build -p aw-sync --target "$target" --lib --no-default-features "${release_args[@]}"
 done

--- a/compile-android.sh
+++ b/compile-android.sh
@@ -82,22 +82,22 @@ for archtargetstr in \
     export RUSTFLAGS="$ORIG_RUSTFLAGS"
     # Need to set AR for target since NDK 21+:
     #   https://github.com/rust-lang/cc-rs/issues/636#issuecomment-1075352495
+    cc="$NDK_ARCH_DIR/${target}-clang"
+    if [ "$arch" = "arm" ]; then
+        cc="$NDK_ARCH_DIR/arm-linux-androideabi-clang"
+    fi
+
     declare -x "AR_${target_underscore}"="$NDK_ARCH_DIR/llvm-ar"
-    declare -x "CC_${target_underscore}"="$NDK_ARCH_DIR/${target}-clang"
+    declare -x "CC_${target_underscore}"="$cc"
     declare -x "RANLIB_${target_underscore}"="$NDK_ARCH_DIR/llvm-ranlib"
 
     # Needed for runtime error: https://github.com/termux/termux-packages/issues/8029
     #   java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "__extenddftf2"
-    libgcc_path="$("$NDK_ARCH_DIR/${target}-clang" -print-libgcc-file-name)"
+    libgcc_path="$("$cc" -print-libgcc-file-name)"
     export RUSTFLAGS+=" -C link-arg=$libgcc_path"
     # Align to 16KB for Android 15 compatibility
     export RUSTFLAGS+=" -C link-arg=-z -C link-arg=max-page-size=16384"
     echo RUSTFLAGS="$RUSTFLAGS"
-
-    # fix armv7 -> arm
-    if [ "$arch" = "arm" ]; then
-        declare -x "CC_${target_underscore}"="$NDK_ARCH_DIR/arm-linux-androideabi-clang"
-    fi
 
     # check that they exist
     for var in AR_${target_underscore} CC_${target_underscore} RANLIB_${target_underscore}; do

--- a/scripts/test-compile-android-cwd.sh
+++ b/scripts/test-compile-android-cwd.sh
@@ -7,12 +7,13 @@ REPO_ROOT="$(
     cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
     pwd
 )"
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR"' EXIT
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
 
-NDK_BIN="$TMPDIR/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin"
-mkdir -p "$NDK_BIN" "$TMPDIR/ndk/sysroot/lib" "$TMPDIR/bin"
-touch "$TMPDIR/ndk/sysroot/lib/libunwind.a" "$TMPDIR/libgcc.a"
+platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+NDK_BIN="$TEST_DIR/ndk/toolchains/llvm/prebuilt/${platform}-x86_64/bin"
+mkdir -p "$NDK_BIN" "$TEST_DIR/ndk/sysroot/lib" "$TEST_DIR/bin"
+touch "$TEST_DIR/ndk/sysroot/lib/libunwind.a" "$TEST_DIR/libgcc.a"
 
 cat > "$NDK_BIN/llvm-ar" <<'EOF'
 #!/bin/bash
@@ -24,18 +25,25 @@ cat > "$NDK_BIN/llvm-ranlib" <<'EOF'
 exit 0
 EOF
 
-cat > "$NDK_BIN/aarch64-linux-android-clang" <<EOF
+write_clang_stub() {
+    cat > "$NDK_BIN/$1" <<EOF
 #!/bin/bash
 if [ "\$1" = "-print-libgcc-file-name" ]; then
-    echo "$TMPDIR/libgcc.a"
+    echo "$TEST_DIR/libgcc.a"
 fi
 exit 0
 EOF
+}
 
-cat > "$TMPDIR/bin/cargo" <<EOF
+write_clang_stub aarch64-linux-android-clang
+write_clang_stub arm-linux-androideabi-clang
+write_clang_stub i686-linux-android-clang
+write_clang_stub x86_64-linux-android-clang
+
+cat > "$TEST_DIR/bin/cargo" <<EOF
 #!/bin/bash
-printf '%s\n' "\$PWD" >> "$TMPDIR/cargo_pwds.txt"
-printf '%s\n' "\$*" >> "$TMPDIR/cargo_args.txt"
+printf '%s\n' "\$PWD" >> "$TEST_DIR/cargo_pwds.txt"
+printf '%s\n' "\$*" >> "$TEST_DIR/cargo_args.txt"
 exit 0
 EOF
 
@@ -43,32 +51,51 @@ chmod +x \
     "$NDK_BIN/llvm-ar" \
     "$NDK_BIN/llvm-ranlib" \
     "$NDK_BIN/aarch64-linux-android-clang" \
-    "$TMPDIR/bin/cargo"
+    "$NDK_BIN/arm-linux-androideabi-clang" \
+    "$NDK_BIN/i686-linux-android-clang" \
+    "$NDK_BIN/x86_64-linux-android-clang" \
+    "$TEST_DIR/bin/cargo"
 
-(
+run_compile() {
     cd /tmp
-    PATH="$TMPDIR/bin:$PATH" \
-    ANDROID_NDK_HOME="$TMPDIR/ndk" \
+    PATH="$TEST_DIR/bin:$PATH" \
+    ANDROID_NDK_HOME="$TEST_DIR/ndk" \
     RELEASE=false \
-    "$REPO_ROOT/compile-android.sh" arm64 >/dev/null
-)
+    "$REPO_ROOT/compile-android.sh" "$@" >/dev/null
+}
 
-if [ ! -s "$TMPDIR/cargo_pwds.txt" ]; then
-    echo "Expected cargo to be invoked"
+assert_cargo_invocations() {
+    if [ ! -s "$TEST_DIR/cargo_pwds.txt" ]; then
+        echo "Expected cargo to be invoked"
+        exit 1
+    fi
+
+    if [ "$(wc -l < "$TEST_DIR/cargo_pwds.txt")" -ne "$1" ]; then
+        echo "Expected exactly $1 cargo invocations"
+        cat "$TEST_DIR/cargo_args.txt"
+        exit 1
+    fi
+
+    if grep -Fxv "$REPO_ROOT" "$TEST_DIR/cargo_pwds.txt" >/dev/null; then
+        echo "cargo ran outside repo root:"
+        cat "$TEST_DIR/cargo_pwds.txt"
+        exit 1
+    fi
+}
+
+run_compile arm64
+assert_cargo_invocations 2
+grep -F -- "-p aw-server" "$TEST_DIR/cargo_args.txt" >/dev/null
+grep -F -- "-p aw-sync" "$TEST_DIR/cargo_args.txt" >/dev/null
+grep -F -- "--target aarch64-linux-android" "$TEST_DIR/cargo_args.txt" >/dev/null
+if grep -F -- "--target armv7-linux-androideabi" "$TEST_DIR/cargo_args.txt" >/dev/null; then
+    echo "arm64 should not match the arm target"
     exit 1
 fi
 
-if [ "$(wc -l < "$TMPDIR/cargo_pwds.txt")" -ne 2 ]; then
-    echo "Expected exactly two cargo invocations"
-    cat "$TMPDIR/cargo_args.txt"
-    exit 1
-fi
+: > "$TEST_DIR/cargo_pwds.txt"
+: > "$TEST_DIR/cargo_args.txt"
 
-if grep -Fxv "$REPO_ROOT" "$TMPDIR/cargo_pwds.txt" >/dev/null; then
-    echo "cargo ran outside repo root:"
-    cat "$TMPDIR/cargo_pwds.txt"
-    exit 1
-fi
-
-grep -F -- "-p aw-server" "$TMPDIR/cargo_args.txt" >/dev/null
-grep -F -- "-p aw-sync" "$TMPDIR/cargo_args.txt" >/dev/null
+run_compile arm
+assert_cargo_invocations 2
+grep -F -- "--target armv7-linux-androideabi" "$TEST_DIR/cargo_args.txt" >/dev/null

--- a/scripts/test-compile-android-cwd.sh
+++ b/scripts/test-compile-android-cwd.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO_ROOT="$(
+    unset CDPATH
+    cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+    pwd
+)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+NDK_BIN="$TMPDIR/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin"
+mkdir -p "$NDK_BIN" "$TMPDIR/ndk/sysroot/lib" "$TMPDIR/bin"
+touch "$TMPDIR/ndk/sysroot/lib/libunwind.a" "$TMPDIR/libgcc.a"
+
+cat > "$NDK_BIN/llvm-ar" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+cat > "$NDK_BIN/llvm-ranlib" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+cat > "$NDK_BIN/aarch64-linux-android-clang" <<EOF
+#!/bin/bash
+if [ "\$1" = "-print-libgcc-file-name" ]; then
+    echo "$TMPDIR/libgcc.a"
+fi
+exit 0
+EOF
+
+cat > "$TMPDIR/bin/cargo" <<EOF
+#!/bin/bash
+printf '%s\n' "\$PWD" >> "$TMPDIR/cargo_pwds.txt"
+printf '%s\n' "\$*" >> "$TMPDIR/cargo_args.txt"
+exit 0
+EOF
+
+chmod +x \
+    "$NDK_BIN/llvm-ar" \
+    "$NDK_BIN/llvm-ranlib" \
+    "$NDK_BIN/aarch64-linux-android-clang" \
+    "$TMPDIR/bin/cargo"
+
+(
+    cd /tmp
+    PATH="$TMPDIR/bin:$PATH" \
+    ANDROID_NDK_HOME="$TMPDIR/ndk" \
+    RELEASE=false \
+    "$REPO_ROOT/compile-android.sh" arm64 >/dev/null
+)
+
+if [ ! -s "$TMPDIR/cargo_pwds.txt" ]; then
+    echo "Expected cargo to be invoked"
+    exit 1
+fi
+
+if [ "$(wc -l < "$TMPDIR/cargo_pwds.txt")" -ne 2 ]; then
+    echo "Expected exactly two cargo invocations"
+    cat "$TMPDIR/cargo_args.txt"
+    exit 1
+fi
+
+if grep -Fxv "$REPO_ROOT" "$TMPDIR/cargo_pwds.txt" >/dev/null; then
+    echo "cargo ran outside repo root:"
+    cat "$TMPDIR/cargo_pwds.txt"
+    exit 1
+fi
+
+grep -F -- "-p aw-server" "$TMPDIR/cargo_args.txt" >/dev/null
+grep -F -- "-p aw-sync" "$TMPDIR/cargo_args.txt" >/dev/null


### PR DESCRIPTION
## Summary
- run `compile-android.sh` from its own repo root so relative paths and `cargo build` no longer depend on the caller's cwd
- match requested Android targets exactly so `arm64` doesn't also trigger the `arm` build path
- add a stubbed regression test and run it in the Android workflow

Closes #213.

## Testing
- `bash scripts/test-compile-android-cwd.sh`
- `shellcheck compile-android.sh scripts/test-compile-android-cwd.sh`
