### PR TITLE
fix(ci): harden dependabot automerge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,5 +1,11 @@
 name: Dependabot Auto-merge
 
+# NOTE: `merge-me-action` still needs the bot PAT here.
+# Using `secrets.GITHUB_TOKEN` fails on `workflow_run` with
+# "Resource not accessible by integration" when the action queries
+# branch protection rules over GraphQL.
+# See: https://github.com/ridedott/merge-me-action/issues/1581
+
 on:
   workflow_run:
     types:
@@ -8,17 +14,16 @@ on:
       # List all required workflow names here.
       - Build
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   auto_merge:
     name: Auto-merge
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && github.actor == 'dependabot[bot]'
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.actor == 'dependabot[bot]'
 
     steps:
-      - uses: ridedott/merge-me-action@v2
+      - uses: ridedott/merge-me-action@2568f177a681785a874d6e7af950eb1a0dd31123
         with:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.AWBOT_GH_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,8 +1,5 @@
 name: Dependabot Auto-merge
 
-# NOTE: This workflow relies on a Personal Access Token from the @ActivityWatchBot user
-#       See this issue for details: https://github.com/ridedott/merge-me-action/issues/1581
-
 on:
   workflow_run:
     types:
@@ -13,7 +10,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   auto_merge:
@@ -24,4 +21,4 @@ jobs:
     steps:
       - uses: ridedott/merge-me-action@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.AWBOT_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This follows the merged aw-webui correction in ActivityWatch/aw-webui#837.

The failed master run shows `AWBOT_GH_TOKEN` currently returns `Bad credentials`, but `merge-me-action` also cannot use the built-in `GITHUB_TOKEN` in this `workflow_run` path because it queries branch protection over GraphQL and gets `Resource not accessible by integration`.

So the workflow still needs a live ActivityWatchBot PAT. This PR makes that explicit and hardens the surrounding workflow:

- keep `secrets.AWBOT_GH_TOKEN` for `merge-me-action` and document why
- remove the inert workflow-level `permissions` block, since the PAT-authenticated action does not use it
- restrict auto-merge to successful `pull_request` workflow runs from Dependabot
- pin `ridedott/merge-me-action` to commit SHA `2568f177a681785a874d6e7af950eb1a0dd31123`

Maintainer note: if the repo secret has not already been rotated, `AWBOT_GH_TOKEN` still needs to be updated in repository settings. The code-side `GITHUB_TOKEN` workaround is not viable for this action.

## Verification

- reproduced the failing master run: `gh run view 26257321530 --repo ActivityWatch/aw-server-rust --log-failed`
- validated the updated workflow YAML locally with `python3` + `yaml.safe_load`
- `git diff --check -- .github/workflows/dependabot-automerge.yml`
