### PR TITLE
fix(classify): honor rule order across branches

### DIFF
--- a/aw-transform/src/classify.rs
+++ b/aw-transform/src/classify.rs
@@ -143,8 +143,12 @@ fn tag_one(mut event: Event, rules: &[(String, Rule)]) -> Event {
 }
 
 fn _pick_highest_ranking_category(acc: Vec<String>, item: &[String]) -> Vec<String> {
-    if item.len() >= acc.len() {
-        // If tag is category with greater or equal depth than current, then choose the new one instead.
+    if acc == ["Uncategorized"] {
+        item.to_vec()
+    } else if item.len() > acc.len() && item.starts_with(&acc) {
+        // Rule order decides between unrelated categories. A later rule only
+        // overrides an earlier match when it is a more specific child of the
+        // already selected category.
         item.to_vec()
     } else {
         acc
@@ -266,6 +270,32 @@ fn test_categorize_uncategorized() {
     assert_eq!(
         events.first().unwrap().data.get("$category").unwrap(),
         &serde_json::json!(vec!["Uncategorized"])
+    );
+}
+
+#[test]
+fn test_categorize_keeps_earlier_unrelated_category() {
+    let mut e = Event::default();
+    e.data
+        .insert("test".into(), serde_json::json!("just a test"));
+
+    let mut events = vec![e];
+    let rules: Vec<(Vec<String>, Rule)> = vec![
+        (
+            vec!["First".into()],
+            Rule::from(Regex::new(r"test").unwrap()),
+        ),
+        (
+            vec!["Second".into(), "Child".into()],
+            Rule::from(Regex::new(r"test").unwrap()),
+        ),
+    ];
+    events = categorize(events, &rules);
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events.first().unwrap().data.get("$category").unwrap(),
+        &serde_json::json!(vec!["First"])
     );
 }
 

--- a/aw-transform/src/classify.rs
+++ b/aw-transform/src/classify.rs
@@ -95,7 +95,9 @@ impl From<Regex> for Rule {
 ///
 /// An event can only have one category, although the category may have a hierarchy,
 /// for instance: "Work -> ActivityWatch -> aw-server-rust"
-/// If multiple categories match, the deepest one will be chosen.
+/// If multiple categories match, the first-matching rule wins, except that
+/// a later rule may override when it is a strictly deeper descendant of the
+/// currently selected category (honouring rule order across unrelated branches).
 pub fn categorize(mut events: Vec<Event>, rules: &[(Vec<String>, Rule)]) -> Vec<Event> {
     let mut classified_events = Vec::new();
     for event in events.drain(..) {
@@ -105,7 +107,7 @@ pub fn categorize(mut events: Vec<Event>, rules: &[(Vec<String>, Rule)]) -> Vec<
 }
 
 fn categorize_one(mut event: Event, rules: &[(Vec<String>, Rule)]) -> Event {
-    let mut category: Vec<String> = vec!["Uncategorized".into()];
+    let mut category: Vec<String> = vec![UNCATEGORIZED.into()];
     for (cat, rule) in rules {
         if rule.matches(&event) {
             category = _pick_highest_ranking_category(category, cat);
@@ -142,8 +144,10 @@ fn tag_one(mut event: Event, rules: &[(String, Rule)]) -> Event {
     event
 }
 
+const UNCATEGORIZED: &str = "Uncategorized";
+
 fn _pick_highest_ranking_category(acc: Vec<String>, item: &[String]) -> Vec<String> {
-    if acc == ["Uncategorized"] {
+    if acc == [UNCATEGORIZED] {
         item.to_vec()
     } else if item.len() > acc.len() && item.starts_with(&acc) {
         // Rule order decides between unrelated categories. A later rule only


### PR DESCRIPTION
Closes #597.

## Summary
- keep the first matching category when a later match is from an unrelated branch
- still allow a later match to override when it is a deeper child of the already selected category
- add a regression test for the reported `Category 1` vs `Category 2 -> Category 2b` case

## Verification
- `cargo test -p aw-transform`
