### PR TITLE
perf(datastore): enable WAL journal mode

### DIFF
--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -197,6 +197,15 @@ impl DatastoreWorker {
 
             self.uncommitted_events = 0;
             self.commit = false;
+            // ForceCommit and Close promise the caller that their data is
+            // committed, so their acks are held back until the transaction
+            // below has actually committed. Acking first (as before) let a
+            // caller reopen the database and read a pre-commit snapshot —
+            // harmless under the rollback journal's locking, but a real race
+            // in WAL mode where readers never block on the writer.
+            // All other commands are acked immediately: a watcher heartbeat
+            // must not wait up to 15 s for the batch commit.
+            let mut deferred_ack = None;
             loop {
                 let (request, response_sender) = match self.responder.poll() {
                     Ok((req, res_sender)) => (req, res_sender),
@@ -207,7 +216,13 @@ impl DatastoreWorker {
                         break;
                     }
                 };
+                let ack_after_commit = matches!(request, Command::ForceCommit() | Command::Close());
                 let response = self.handle_request(request, &mut ds, &tx);
+                if ack_after_commit {
+                    // Both commands force a commit, so the loop ends here.
+                    deferred_ack = Some((response_sender, response));
+                    break;
+                }
                 response_sender.respond(response);
 
                 let now: DateTime<Utc> = Utc::now();
@@ -225,7 +240,11 @@ impl DatastoreWorker {
                 self.commit, self.uncommitted_events
             );
             match tx.commit() {
-                Ok(_) => (),
+                Ok(_) => {
+                    if let Some((sender, response)) = deferred_ack.take() {
+                        sender.respond(response);
+                    }
+                }
                 Err(err) => {
                     error!(
                         "Failed to commit datastore transaction ({} events lost): {err}",
@@ -237,6 +256,11 @@ impl DatastoreWorker {
                     // know to retry. Rolled-back events create a gap in the timeline;
                     // watchers will resume sending heartbeats from current state, but the
                     // specific batch of events is permanently lost.
+                    if let Some((sender, _)) = deferred_ack.take() {
+                        sender.respond(Err(DatastoreError::InternalError(format!(
+                            "Failed to commit datastore transaction: {err}"
+                        ))));
+                    }
                 }
             }
             if self.quit {

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -138,6 +138,24 @@ impl DatastoreWorker {
                 conn
             }
         };
+
+        // WAL turns each commit into a single sequential WAL append+fsync where
+        // delete mode paid two fsyncs plus journal-file churn, and lets future
+        // reader connections proceed while a commit is in flight.
+        // synchronous=FULL is set explicitly (rather than relying on the
+        // default) so a commit remains durable on disk the moment it returns;
+        // with NORMAL the WAL is only synced at checkpoints, which would
+        // silently widen the loss window on power failure.
+        // In-memory databases ignore the request (journal_mode stays "memory").
+        let journal_mode: String = conn
+            .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get(0))
+            .expect("Failed to query journal_mode");
+        if !matches!(&method, DatastoreMethod::Memory()) && journal_mode != "wal" {
+            warn!("Failed to enable WAL (journal_mode={journal_mode}), continuing without it");
+        }
+        conn.pragma_update(None, "synchronous", "FULL")
+            .expect("Failed to set synchronous=FULL");
+
         let mut ds = DatastoreInstance::new(&conn, true).unwrap();
 
         // Ensure legacy import


### PR DESCRIPTION
Re-lands the WAL change that was split out of #615 so that PR could merge, together with a fix for the race that made `test_datastore_reload` fail on the ubuntu runner when this was briefly part of #615 (run [27410891058](https://github.com/ActivityWatch/aw-server-rust/actions/runs/27410891058)).

## Commits

**`perf(datastore): enable WAL journal mode with synchronous=FULL`**

Each batch commit becomes a single sequential WAL append+fsync where delete mode paid two fsyncs plus rollback-journal file create/delete churn, and commits no longer block readers — groundwork for serving reads from parallel read-only connections later (the existing TODO at the top of `worker.rs`).

- No db migration involved: `journal_mode=WAL` is set at connection open and persists in the db header; any SQLite ≥ 3.7.0 (2010) can still open the file.
- In-memory datastores (tests, `--no-db`) ignore it and keep `journal_mode=memory`.
- Verified on a 98 MB / 544k-event production snapshot: WAL active, clean checkpoint on shutdown, `integrity_check` ok, heartbeat throughput +4% on top of the #615 numbers (5,572 → 5,815/s), reads unchanged.

**`fix(datastore): ack ForceCommit/Close only after the transaction commits`**

This is the actual cause of the ubuntu CI failure, a pre-existing bug that WAL unmasked rather than a WAL problem: the worker acked `ForceCommit`/`Close` inside the request loop, but `tx.commit()` only runs after breaking out of it — so `force_commit()` returned while the data was still uncommitted. `test_datastore_reload` calls `force_commit()`, reopens the datastore, and the new instance populates its bucket-metadata cache from a snapshot that could predate the commit. The rollback journal's locking happened to serialize the second reader behind the commit; in WAL readers never block on the writer, so the stale read became reachable (macOS won the race, ubuntu lost it).

The acks for these two commands are now held until `tx.commit()` returns, and a failed commit is propagated to the caller as an error instead of a silent success — this also fixes `close()` acknowledging shutdown before the final commit was durable. All other commands (heartbeats in particular) are still acked immediately and never wait on the batch commit. `test_datastore_reload` passed 50/50 stress iterations with the fix; full workspace suite green.

## Why `synchronous=FULL` and not `NORMAL`?

Raised by @ErikBjare on #615 — the usual "WAL+NORMAL for many small writes" advice doesn't transfer here because the worker already does group commit at the application level: all writes accumulate in one transaction committed every 15 s / 100 events / on bucket change. The per-commit fsync that NORMAL exists to eliminate happens ~4×/minute, not per heartbeat — it isn't in the per-write path at all (the +4% above was measured *with* FULL, hammering writes ~1000× faster than real watchers).

What NORMAL would cost: the WAL is then only synced at checkpoints, and autocheckpoint triggers on page count (1000 pages), not time — at AW's trickle write rate a power loss could drop hours of activity since the last checkpoint, vs ≤15 s today. Bounding that would need a time-based `wal_checkpoint`, i.e. fsyncing on a timer — which is what FULL already does, given commits are timer-driven. FULL keeps exactly the durability semantics the server has always had (delete mode's default is FULL), with strictly fewer syncs than before.

Readers are unaffected either way: in WAL the commit fsync holds only the write lock, and there's a single application-level writer.
