### PR TITLE
feat(android): add migration for aw-watcher-android-test bucket names

### DIFF
--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -1037,4 +1037,40 @@ impl DatastoreInstance {
             },
         }
     }
+
+    /// Migrates all buckets whose hostname is "unknown" or "Unknown" to `new_hostname`.
+    /// Events are left untouched; only the bucket metadata is updated.
+    /// Returns the number of buckets that were updated.
+    pub fn migrate_hostname(
+        &mut self,
+        conn: &Connection,
+        new_hostname: &str,
+    ) -> Result<usize, DatastoreError> {
+        info!(
+            "Migrating hostname from 'unknown'/'Unknown' to '{}'",
+            new_hostname
+        );
+
+        let updated = match conn.execute(
+            "UPDATE buckets SET hostname = ?1 WHERE hostname = 'unknown' OR hostname = 'Unknown'",
+            [new_hostname],
+        ) {
+            Ok(n) => n,
+            Err(err) => {
+                return Err(DatastoreError::InternalError(format!(
+                    "Failed to migrate hostname: {err}"
+                )))
+            }
+        };
+
+        if updated > 0 {
+            info!("Migrated hostname for {} bucket(s)", updated);
+            // Refresh the in-memory cache so callers see the new hostnames immediately.
+            self.get_stored_buckets(conn)?;
+        } else {
+            info!("No buckets with hostname 'unknown'/'Unknown' found; nothing to migrate");
+        }
+
+        Ok(updated)
+    }
 }

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -1116,7 +1116,9 @@ impl DatastoreInstance {
     /// `aw-watcher-android` instead.  This covers the old debug-build bucket naming
     /// convention (e.g. `aw-watcher-android-test_hostname` → `aw-watcher-android_hostname`).
     /// Events are left untouched; only the bucket metadata is updated.
-    /// Returns the number of buckets that were updated.
+    /// Returns the number of buckets that were migrated.
+    /// Note: if a UNIQUE constraint violation occurs on any single row, `UPDATE OR IGNORE`
+    /// will skip conflicting rows instead of aborting the entire batch.
     pub fn migrate_test_bucket_names(
         &mut self,
         conn: &Connection,
@@ -1124,7 +1126,7 @@ impl DatastoreInstance {
         info!("Migrating 'aw-watcher-android-test' bucket names to 'aw-watcher-android'");
 
         let updated = match conn.execute(
-            "UPDATE buckets SET name = REPLACE(name, 'aw-watcher-android-test', 'aw-watcher-android') \
+            "UPDATE OR IGNORE buckets SET name = 'aw-watcher-android' || SUBSTR(name, LENGTH('aw-watcher-android-test') + 1) \
              WHERE name LIKE 'aw-watcher-android-test%'",
             [],
         ) {

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -1038,6 +1038,44 @@ impl DatastoreInstance {
         }
     }
 
+    /// Renames a bucket from `old_id` to `new_id`.
+    /// Events are left untouched because they reference the integer row ID, not the name.
+    /// Returns `NoSuchBucket` if `old_id` does not exist, or `BucketAlreadyExists` if
+    /// `new_id` is already taken.
+    pub fn rename_bucket(
+        &mut self,
+        conn: &Connection,
+        old_id: &str,
+        new_id: &str,
+    ) -> Result<(), DatastoreError> {
+        if !self.buckets_cache.contains_key(old_id) {
+            return Err(DatastoreError::NoSuchBucket(old_id.to_string()));
+        }
+        if self.buckets_cache.contains_key(new_id) {
+            return Err(DatastoreError::BucketAlreadyExists(new_id.to_string()));
+        }
+
+        match conn.execute(
+            "UPDATE buckets SET name = ?1 WHERE name = ?2",
+            [new_id, old_id],
+        ) {
+            Ok(0) => Err(DatastoreError::NoSuchBucket(old_id.to_string())),
+            Ok(_) => {
+                info!("Renamed bucket '{}' to '{}'", old_id, new_id);
+                // Update the in-memory cache: remove the old entry and re-insert under the new id.
+                if let Some(mut bucket) = self.buckets_cache.remove(old_id) {
+                    bucket.id = new_id.to_string();
+                    self.buckets_cache.insert(new_id.to_string(), bucket);
+                }
+                Ok(())
+            }
+            Err(err) => Err(DatastoreError::InternalError(format!(
+                "Failed to rename bucket '{}' to '{}': {err}",
+                old_id, new_id
+            ))),
+        }
+    }
+
     /// Migrates all buckets whose hostname is "unknown" or "Unknown" to `new_hostname`.
     /// Events are left untouched; only the bucket metadata is updated.
     /// Returns the number of buckets that were updated.

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -1111,4 +1111,39 @@ impl DatastoreInstance {
 
         Ok(updated)
     }
+
+    /// Migrates all buckets whose name starts with `aw-watcher-android-test` to use
+    /// `aw-watcher-android` instead.  This covers the old debug-build bucket naming
+    /// convention (e.g. `aw-watcher-android-test_hostname` → `aw-watcher-android_hostname`).
+    /// Events are left untouched; only the bucket metadata is updated.
+    /// Returns the number of buckets that were updated.
+    pub fn migrate_test_bucket_names(
+        &mut self,
+        conn: &Connection,
+    ) -> Result<usize, DatastoreError> {
+        info!("Migrating 'aw-watcher-android-test' bucket names to 'aw-watcher-android'");
+
+        let updated = match conn.execute(
+            "UPDATE buckets SET name = REPLACE(name, 'aw-watcher-android-test', 'aw-watcher-android') \
+             WHERE name LIKE 'aw-watcher-android-test%'",
+            [],
+        ) {
+            Ok(n) => n,
+            Err(err) => {
+                return Err(DatastoreError::InternalError(format!(
+                    "Failed to migrate test bucket names: {err}"
+                )))
+            }
+        };
+
+        if updated > 0 {
+            info!("Migrated {} 'aw-watcher-android-test' bucket(s)", updated);
+            // Refresh the in-memory cache so callers see the new names immediately.
+            self.get_stored_buckets(conn)?;
+        } else {
+            info!("No 'aw-watcher-android-test' buckets found; nothing to migrate");
+        }
+
+        Ok(updated)
+    }
 }

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -80,6 +80,7 @@ pub enum Command {
     RefreshPrivacyFilter(),
     RenameBucket(String, String),
     MigrateHostname(String),
+    MigrateTestBucketNames(),
     Close(),
 }
 
@@ -424,6 +425,17 @@ impl DatastoreWorker {
                     Err(e) => Err(e),
                 }
             }
+            Command::MigrateTestBucketNames() => {
+                match ds.migrate_test_bucket_names(tx) {
+                    Ok(count) => {
+                        if count > 0 {
+                            self.commit = true;
+                        }
+                        Ok(Response::Count(count as i64))
+                    }
+                    Err(e) => Err(e),
+                }
+            }
             Command::Close() => {
                 self.quit = true;
                 Ok(Response::Empty())
@@ -657,6 +669,23 @@ impl Datastore {
                 Response::Count(n) => Ok(n as usize),
                 _ => Err(DatastoreError::InternalError(
                     "Unexpected response to MigrateHostname command".to_string(),
+                )),
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Migrates all buckets whose name starts with `aw-watcher-android-test` to use
+    /// `aw-watcher-android` instead (e.g. debug-build buckets from older app versions).
+    /// Returns the number of buckets updated.
+    pub fn migrate_test_bucket_names(&self) -> Result<usize, DatastoreError> {
+        let cmd = Command::MigrateTestBucketNames();
+        let receiver = self.requester.request(cmd).unwrap();
+        match receiver.collect().unwrap() {
+            Ok(r) => match r {
+                Response::Count(n) => Ok(n as usize),
+                _ => Err(DatastoreError::InternalError(
+                    "Unexpected response to MigrateTestBucketNames command".to_string(),
                 )),
             },
             Err(e) => Err(e),

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -425,17 +425,15 @@ impl DatastoreWorker {
                     Err(e) => Err(e),
                 }
             }
-            Command::MigrateTestBucketNames() => {
-                match ds.migrate_test_bucket_names(tx) {
-                    Ok(count) => {
-                        if count > 0 {
-                            self.commit = true;
-                        }
-                        Ok(Response::Count(count as i64))
+            Command::MigrateTestBucketNames() => match ds.migrate_test_bucket_names(tx) {
+                Ok(count) => {
+                    if count > 0 {
+                        self.commit = true;
                     }
-                    Err(e) => Err(e),
+                    Ok(Response::Count(count as i64))
                 }
-            }
+                Err(e) => Err(e),
+            },
             Command::Close() => {
                 self.quit = true;
                 Ok(Response::Empty())
@@ -655,8 +653,7 @@ impl Datastore {
     /// Renames a bucket from `old_id` to `new_id`.
     pub fn rename_bucket(&self, old_id: &str, new_id: &str) -> Result<(), DatastoreError> {
         let cmd = Command::RenameBucket(old_id.to_string(), new_id.to_string());
-        let receiver = self.requester.request(cmd).unwrap();
-        _unwrap_response(receiver)
+        _unwrap_empty_response(self.request(cmd)?)
     }
 
     /// Migrates all buckets whose hostname is "unknown" or "Unknown" to `new_hostname`.

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -660,15 +660,11 @@ impl Datastore {
     /// Returns the number of buckets updated.
     pub fn migrate_hostname(&self, new_hostname: &str) -> Result<usize, DatastoreError> {
         let cmd = Command::MigrateHostname(new_hostname.to_string());
-        let receiver = self.requester.request(cmd).unwrap();
-        match receiver.collect().unwrap() {
-            Ok(r) => match r {
-                Response::Count(n) => Ok(n as usize),
-                _ => Err(DatastoreError::InternalError(
-                    "Unexpected response to MigrateHostname command".to_string(),
-                )),
-            },
-            Err(e) => Err(e),
+        match self.request(cmd)? {
+            Response::Count(n) => Ok(n as usize),
+            _ => Err(DatastoreError::InternalError(
+                "Unexpected response to MigrateHostname command".to_string(),
+            )),
         }
     }
 
@@ -677,15 +673,11 @@ impl Datastore {
     /// Returns the number of buckets updated.
     pub fn migrate_test_bucket_names(&self) -> Result<usize, DatastoreError> {
         let cmd = Command::MigrateTestBucketNames();
-        let receiver = self.requester.request(cmd).unwrap();
-        match receiver.collect().unwrap() {
-            Ok(r) => match r {
-                Response::Count(n) => Ok(n as usize),
-                _ => Err(DatastoreError::InternalError(
-                    "Unexpected response to MigrateTestBucketNames command".to_string(),
-                )),
-            },
-            Err(e) => Err(e),
+        match self.request(cmd)? {
+            Response::Count(n) => Ok(n as usize),
+            _ => Err(DatastoreError::InternalError(
+                "Unexpected response to MigrateTestBucketNames command".to_string(),
+            )),
         }
     }
 

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -78,6 +78,7 @@ pub enum Command {
     SetKeyValue(String, String),
     DeleteKeyValue(String),
     RefreshPrivacyFilter(),
+    MigrateHostname(String),
     Close(),
 }
 
@@ -404,6 +405,17 @@ impl DatastoreWorker {
                 }
                 Ok(Response::Empty())
             }
+            Command::MigrateHostname(new_hostname) => {
+                match ds.migrate_hostname(tx, &new_hostname) {
+                    Ok(count) => {
+                        if count > 0 {
+                            self.commit = true;
+                        }
+                        Ok(Response::Count(count as i64))
+                    }
+                    Err(e) => Err(e),
+                }
+            }
             Command::Close() => {
                 self.quit = true;
                 Ok(Response::Empty())
@@ -618,6 +630,22 @@ impl Datastore {
 
     pub fn refresh_privacy_filter(&self) -> Result<(), DatastoreError> {
         _unwrap_empty_response(self.request(Command::RefreshPrivacyFilter())?)
+    }
+
+    /// Migrates all buckets whose hostname is "unknown" or "Unknown" to `new_hostname`.
+    /// Returns the number of buckets updated.
+    pub fn migrate_hostname(&self, new_hostname: &str) -> Result<usize, DatastoreError> {
+        let cmd = Command::MigrateHostname(new_hostname.to_string());
+        let receiver = self.requester.request(cmd).unwrap();
+        match receiver.collect().unwrap() {
+            Ok(r) => match r {
+                Response::Count(n) => Ok(n as usize),
+                _ => Err(DatastoreError::InternalError(
+                    "Unexpected response to MigrateHostname command".to_string(),
+                )),
+            },
+            Err(e) => Err(e),
+        }
     }
 
     // Should block until worker has stopped

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -78,6 +78,7 @@ pub enum Command {
     SetKeyValue(String, String),
     DeleteKeyValue(String),
     RefreshPrivacyFilter(),
+    RenameBucket(String, String),
     MigrateHostname(String),
     Close(),
 }
@@ -405,6 +406,13 @@ impl DatastoreWorker {
                 }
                 Ok(Response::Empty())
             }
+            Command::RenameBucket(old_id, new_id) => match ds.rename_bucket(tx, &old_id, &new_id) {
+                Ok(()) => {
+                    self.commit = true;
+                    Ok(Response::Empty())
+                }
+                Err(e) => Err(e),
+            },
             Command::MigrateHostname(new_hostname) => {
                 match ds.migrate_hostname(tx, &new_hostname) {
                     Ok(count) => {
@@ -630,6 +638,13 @@ impl Datastore {
 
     pub fn refresh_privacy_filter(&self) -> Result<(), DatastoreError> {
         _unwrap_empty_response(self.request(Command::RefreshPrivacyFilter())?)
+    }
+
+    /// Renames a bucket from `old_id` to `new_id`.
+    pub fn rename_bucket(&self, old_id: &str, new_id: &str) -> Result<(), DatastoreError> {
+        let cmd = Command::RenameBucket(old_id.to_string(), new_id.to_string());
+        let receiver = self.requester.request(cmd).unwrap();
+        _unwrap_response(receiver)
     }
 
     /// Migrates all buckets whose hostname is "unknown" or "Unknown" to `new_hostname`.

--- a/aw-server/src/android/mod.rs
+++ b/aw-server/src/android/mod.rs
@@ -267,6 +267,20 @@ pub mod android {
     }
 
     #[no_mangle]
+    pub unsafe extern "C" fn Java_net_activitywatch_android_RustInterface_migrateAndroidBucketName(
+        env: JNIEnv,
+        _: JClass,
+    ) -> jstring {
+        match openDatastore().rename_bucket("aw-android-test", "aw-android") {
+            Ok(()) => string_to_jstring(
+                &env,
+                "Renamed bucket 'aw-android-test' to 'aw-android'".to_string(),
+            ),
+            Err(e) => create_error_object(&env, format!("Failed to rename bucket: {:?}", e)),
+        }
+    }
+
+    #[no_mangle]
     pub unsafe extern "C" fn Java_net_activitywatch_android_RustInterface_query(
         env: JNIEnv,
         _: JClass,

--- a/aw-server/src/android/mod.rs
+++ b/aw-server/src/android/mod.rs
@@ -281,6 +281,23 @@ pub mod android {
     }
 
     #[no_mangle]
+    pub unsafe extern "C" fn Java_net_activitywatch_android_RustInterface_migrateWatcherAndroidBucketNames(
+        env: JNIEnv,
+        _: JClass,
+    ) -> jstring {
+        match openDatastore().migrate_test_bucket_names() {
+            Ok(count) => string_to_jstring(
+                &env,
+                format!("Migrated {} 'aw-watcher-android-test' bucket(s)", count),
+            ),
+            Err(e) => create_error_object(
+                &env,
+                format!("Failed to migrate watcher bucket names: {:?}", e),
+            ),
+        }
+    }
+
+    #[no_mangle]
     pub unsafe extern "C" fn Java_net_activitywatch_android_RustInterface_query(
         env: JNIEnv,
         _: JClass,

--- a/aw-server/src/android/mod.rs
+++ b/aw-server/src/android/mod.rs
@@ -249,6 +249,24 @@ pub mod android {
     }
 
     #[no_mangle]
+    pub unsafe extern "C" fn Java_net_activitywatch_android_RustInterface_migrateHostname(
+        env: JNIEnv,
+        _: JClass,
+        hostname: JString,
+    ) -> jstring {
+        let hostname = jstring_to_string(&env, hostname);
+        if hostname.is_empty() {
+            return create_error_object(&env, "hostname must not be empty".to_string());
+        }
+        match openDatastore().migrate_hostname(&hostname) {
+            Ok(count) => {
+                string_to_jstring(&env, format!("Migrated hostname for {} bucket(s)", count))
+            }
+            Err(e) => create_error_object(&env, format!("Failed to migrate hostname: {:?}", e)),
+        }
+    }
+
+    #[no_mangle]
     pub unsafe extern "C" fn Java_net_activitywatch_android_RustInterface_query(
         env: JNIEnv,
         _: JClass,


### PR DESCRIPTION
Implements the `aw-watcher-android-test` -> `aw-watcher-android` bucket name migration requested in #577 (comment) and ActivityWatch/aw-android#150, plus the `migrate_hostname()` and `rename_bucket()` infrastructure from #577 with the JNI naming fix already applied.

## Changes

- `aw-datastore/src/datastore.rs`: `rename_bucket()`, `migrate_hostname()`, `migrate_test_bucket_names()`
- `aw-datastore/src/worker.rs`: `RenameBucket`, `MigrateHostname`, `MigrateTestBucketNames` commands + public API
- `aw-server/src/android/mod.rs`: Three JNI entry points using camelCase naming (no JNI `_1` encoding issues)

### `migrate_test_bucket_names()`

Renames all `aw-watcher-android-test*` buckets to `aw-watcher-android*` using safe prefix-only replacement. Uses `OR IGNORE` to skip UNIQUE collisions gracefully, and `SUBSTR` prefix replacement rather than global `REPLACE`.

## Status

- CI green (8/8 checks: ubuntu, windows, macOS, Android, clippy, format, coverage, Greptile)
- Both Greptile review findings fixed and threads resolved (P1: `OR IGNORE`, P2: `SUBSTR` prefix swap)
- JNI naming uses camelCase (no `_1` encoding issues)
- Includes commits from #577 with JNI fix already applied -- independently mergeable

Ref: ActivityWatch/aw-android#150, #577