### PR TITLE
fix(android): update JNI androidQuery bucket name to aw-watcher-android

### DIFF
--- a/aw-server/src/android/mod.rs
+++ b/aw-server/src/android/mod.rs
@@ -343,8 +343,8 @@ pub mod android {
             Err(err) => return create_error_object(&env, err.to_string()),
         };
 
-        // Hardcoded bucket ID for testing
-        let bid_android = "aw-watcher-android-test".to_string();
+        // Hardcoded bucket ID
+        let bid_android = "aw-watcher-android".to_string();
 
         // Get classes from server settings via HTTP API
         let classes = match AwClient::new("127.0.0.1", 5600, "aw-android-query") {

--- a/aw-transform/src/find_bucket.rs
+++ b/aw-transform/src/find_bucket.rs
@@ -7,18 +7,27 @@ pub fn find_bucket<'a>(
     hostname_filter: &Option<String>,
     buckets: impl IntoIterator<Item = &'a Bucket>,
 ) -> Option<String> {
+    let mut prefix_match = None;
     for bucket in buckets {
         if bucket.id.starts_with(bucket_filter) {
-            if let Some(hostname) = hostname_filter {
-                if hostname == &bucket.hostname {
+            let hostname_matches = match hostname_filter {
+                Some(hostname) => hostname == &bucket.hostname,
+                None => true,
+            };
+
+            if hostname_matches {
+                if bucket.id == bucket_filter {
+                    // Exact match, return immediately
                     return Some(bucket.id.to_string());
                 }
-            } else {
-                return Some(bucket.id.to_string());
+                if prefix_match.is_none() {
+                    // Save the first prefix match in case we don't find an exact match
+                    prefix_match = Some(bucket.id.to_string());
+                }
             }
         }
     }
-    None
+    prefix_match
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes https://github.com/ActivityWatch/aw-android/issues/191

This fixes an issue introduced in #628 where the legacy '-test' suffix was dropped from buckets but not from the query.