### PR TITLE
fix(cors): scope the moz-extension wildcard to aw-watcher-web endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,7 @@ dependencies = [
  "log",
  "log-panics",
  "openssl-sys",
+ "regex",
  "rocket",
  "rocket_cors",
  "rust-embed",

--- a/aw-server/Cargo.toml
+++ b/aw-server/Cargo.toml
@@ -34,6 +34,7 @@ lazy_static = "1.4"
 log = "0.4"
 fern = { version = "0.7", features = ["colored"] }
 toml = "0.8"
+regex = "1"
 gethostname = "0.4"
 uuid = { version = "1.3", features = ["serde", "v4"] }
 clap = { version = "4.1", features = ["derive", "cargo"] }

--- a/aw-server/src/endpoints/cors.rs
+++ b/aw-server/src/endpoints/cors.rs
@@ -16,7 +16,10 @@ pub fn cors(config: &AWConfig) -> rocket_cors::Cors {
     let mut allowed_regex_origins = vec![
         "chrome-extension://nglaklhklhcoonedhgnpgddginnjdadi".to_string(),
         // Every version of a mozilla extension has its own ID to avoid fingerprinting, so we
-        // unfortunately have to allow all extensions to have access to aw-server
+        // unfortunately have to allow all extensions to have access to aw-server.
+        // The endpoints this wildcard actually reaches are narrowed to the ones
+        // aw-watcher-web needs by the ExtensionCorsScope fairing — see
+        // endpoints/extension_cors.rs.
         "moz-extension://.*".to_string(),
     ];
     allowed_regex_origins.extend(config.cors_regex.clone());

--- a/aw-server/src/endpoints/extension_cors.rs
+++ b/aw-server/src/endpoints/extension_cors.rs
@@ -10,8 +10,8 @@
 //! actually uses:
 //!
 //! - `GET /api/0/info` — hostname/version detection
-//! - `POST /api/0/buckets/<id>` — ensure bucket
-//! - `POST /api/0/buckets/<id>/heartbeat` — heartbeats
+//! - `POST /api/0/buckets/aw-watcher-web-<id>` — ensure its web-watcher bucket
+//! - `POST /api/0/buckets/aw-watcher-web-<id>/heartbeat` — heartbeats
 //!
 //! Everything else (`/api/0/export`, `/api/0/import`, `/api/0/query`,
 //! `/api/0/settings`, event reads, bucket deletion, ...) is closed to
@@ -147,13 +147,18 @@ fn effective_method(request: &Request) -> Option<Method> {
 }
 
 /// The endpoints `aw-watcher-web` needs, as decoded path segments.
+///
+/// The bucket prefix matters: without it, any installed extension could send
+/// heartbeats to an existing bucket owned by another watcher.
 fn is_watcher_endpoint(method: Method, segments: &[&str]) -> bool {
-    matches!(
-        (method, segments),
-        (Method::Get, ["api", "0", "info"])
-            | (Method::Post, ["api", "0", "buckets", _])
-            | (Method::Post, ["api", "0", "buckets", _, "heartbeat"])
-    )
+    match (method, segments) {
+        (Method::Get, ["api", "0", "info"]) => true,
+        (Method::Post, ["api", "0", "buckets", bucket_id])
+        | (Method::Post, ["api", "0", "buckets", bucket_id, "heartbeat"]) => {
+            bucket_id.starts_with("aw-watcher-web-")
+        }
+        _ => false,
+    }
 }
 
 /// Route handler returning 403 for out-of-scope extension requests.
@@ -328,6 +333,37 @@ mod tests {
             .dispatch();
         assert_eq!(res.status(), Status::Ok, "heartbeat blocked");
         assert_eq!(allow_origin(&res).as_deref(), Some(EXT_ORIGIN));
+    }
+
+    /// A wildcard-matched extension must not create or write to buckets owned
+    /// by other watchers. The URL bucket ID is the downstream authorization
+    /// boundary, so this check must happen before the handler runs.
+    #[test]
+    fn test_extension_cannot_write_other_watcher_bucket() {
+        let client = client();
+
+        let res = client
+            .post("/api/0/buckets/aw-watcher-window_testhost")
+            .header(ContentType::JSON)
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new("Origin", EXT_ORIGIN))
+            .body(r#"{"type":"currentwindow","client":"aw-client","hostname":"testhost"}"#)
+            .dispatch();
+        assert_eq!(res.status(), Status::Forbidden, "foreign bucket created");
+        assert_eq!(allow_origin(&res), None);
+
+        let res = client
+            .post("/api/0/buckets/aw-watcher-window_testhost/heartbeat?pulsetime=60")
+            .header(ContentType::JSON)
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new("Origin", EXT_ORIGIN))
+            .body(
+                r#"{"timestamp":"2026-07-28T09:00:00+00:00","duration":0,
+                    "data":{"app":"attacker","title":"injected"}}"#,
+            )
+            .dispatch();
+        assert_eq!(res.status(), Status::Forbidden, "foreign heartbeat written");
+        assert_eq!(allow_origin(&res), None);
     }
 
     /// Preflight for a watcher endpoint must still succeed — aw-client-js

--- a/aw-server/src/endpoints/extension_cors.rs
+++ b/aw-server/src/endpoints/extension_cors.rs
@@ -13,6 +13,15 @@
 //! - `POST /api/0/buckets/aw-watcher-web-<id>` — ensure its web-watcher bucket
 //! - `POST /api/0/buckets/aw-watcher-web-<id>/heartbeat` — heartbeats
 //!
+//! # Accepted limitation
+//!
+//! The bucket prefix is a coarse scope, not an origin-to-bucket ownership
+//! boundary. Any wildcard-matched Firefox extension can still create or send
+//! heartbeats to another existing `aw-watcher-web-*` bucket. This preserves
+//! the official watcher's zero-configuration flow while blocking writes to
+//! other watcher types; eliminating web-bucket poisoning requires pairing an
+//! extension origin with its bucket in a future protocol.
+//!
 //! Everything else (`/api/0/export`, `/api/0/import`, `/api/0/query`,
 //! `/api/0/settings`, event reads, bucket deletion, ...) is closed to
 //! wildcard-matched extension origins. That removes the data-exfiltration half
@@ -148,8 +157,9 @@ fn effective_method(request: &Request) -> Option<Method> {
 
 /// The endpoints `aw-watcher-web` needs, as decoded path segments.
 ///
-/// The bucket prefix matters: without it, any installed extension could send
-/// heartbeats to an existing bucket owned by another watcher.
+/// The prefix blocks writes to other watcher types, but deliberately does not
+/// bind an extension origin to one `aw-watcher-web-*` bucket. See the accepted
+/// limitation in the module documentation.
 fn is_watcher_endpoint(method: Method, segments: &[&str]) -> bool {
     match (method, segments) {
         (Method::Get, ["api", "0", "info"]) => true,

--- a/aw-server/src/endpoints/extension_cors.rs
+++ b/aw-server/src/endpoints/extension_cors.rs
@@ -1,0 +1,475 @@
+//! Endpoint scoping for the blanket `moz-extension://` CORS origin.
+//!
+//! Firefox gives every install of every extension its own random origin, so
+//! there is no way to allowlist *only* `aw-watcher-web` up front — hence the
+//! `moz-extension://.*` wildcard in [`crate::endpoints::cors`]. The cost is
+//! that any installed extension can talk to the local API, with no host
+//! permission and therefore no install-time prompt naming ActivityWatch.
+//!
+//! This fairing narrows that blanket trust to the endpoints `aw-watcher-web`
+//! actually uses:
+//!
+//! - `GET /api/0/info` — hostname/version detection
+//! - `POST /api/0/buckets/<id>` — ensure bucket
+//! - `POST /api/0/buckets/<id>/heartbeat` — heartbeats
+//!
+//! Everything else (`/api/0/export`, `/api/0/import`, `/api/0/query`,
+//! `/api/0/settings`, event reads, bucket deletion, ...) is closed to
+//! wildcard-matched extension origins. That removes the data-exfiltration half
+//! of the problem — app names, window titles, tab URLs, AFK data — without any
+//! client change.
+//!
+//! Origins the *user* allowed explicitly via `cors_regex` in `config.toml`
+//! are exempt: an explicit allowlist entry is a deliberate opt-in, unlike the
+//! built-in wildcard. (The exact `cors` list cannot express an extension
+//! origin — rocket_cors rejects `moz-extension://` there as an opaque origin —
+//! so `cors_regex` is the only opt-in path for these.)
+//!
+//! # Enforcement
+//!
+//! Two stages, because CORS alone only hides *responses*:
+//!
+//! - `on_request` rejects disallowed requests with 403 before they reach a
+//!   handler. Without this, a "simple" cross-origin `POST` (e.g.
+//!   `text/plain`) is sent by the browser and still executes server-side even
+//!   though the response is unreadable.
+//! - `on_response` strips the `Access-Control-*` headers so preflights for
+//!   disallowed endpoints fail in the browser.
+//!
+//! # Path matching
+//!
+//! Like [`crate::endpoints::apikey`], matching is done on
+//! `request.uri().path().segments()` — the same percent-decoded,
+//! empty-skipping view Rocket's router dispatches on. Matching the raw path
+//! string would let `/%61pi/0/export` desynchronize this gate from the handler
+//! it protects (the bug class of #588 and #636).
+
+use regex::RegexSet;
+
+use rocket::fairing::Fairing;
+use rocket::http::uri::Origin;
+use rocket::http::{Method, Status};
+use rocket::route::Outcome;
+use rocket::{Data, Request, Response, Rocket, Route};
+
+use crate::config::AWConfig;
+use crate::endpoints::HttpErrorJson;
+
+static FAIRING_ROUTE_BASE: &str = "/extension_cors_fairing";
+
+/// Scheme of the origins covered by the built-in wildcard.
+const EXTENSION_ORIGIN_SCHEME: &str = "moz-extension://";
+
+/// CORS response headers to strip when an extension origin is out of scope.
+const CORS_HEADERS: &[&str] = &[
+    "Access-Control-Allow-Origin",
+    "Access-Control-Allow-Methods",
+    "Access-Control-Allow-Headers",
+    "Access-Control-Allow-Credentials",
+    "Access-Control-Expose-Headers",
+    "Access-Control-Max-Age",
+];
+
+pub struct ExtensionCorsScope {
+    /// Regexes from `[server] cors_regex`, matched unanchored like rocket_cors.
+    /// The exact `cors` list is not consulted: rocket_cors cannot hold an
+    /// extension origin there, so it can never allow one.
+    user_regex_origins: Option<RegexSet>,
+}
+
+impl ExtensionCorsScope {
+    pub fn new(config: &AWConfig) -> ExtensionCorsScope {
+        let user_regex_origins = if config.cors_regex.is_empty() {
+            None
+        } else {
+            match RegexSet::new(&config.cors_regex) {
+                Ok(set) => Some(set),
+                Err(e) => {
+                    // rocket_cors will fail on the same input; don't also panic here.
+                    warn!("Invalid cors_regex in config, ignoring for extension scoping: {e}");
+                    None
+                }
+            }
+        };
+        ExtensionCorsScope { user_regex_origins }
+    }
+
+    /// True if the user explicitly allowed this origin in their config.
+    fn user_allowed(&self, origin: &str) -> bool {
+        match &self.user_regex_origins {
+            Some(set) => set.is_match(origin),
+            None => false,
+        }
+    }
+
+    /// True if this request must be blocked for the given origin.
+    fn is_blocked(&self, request: &Request) -> bool {
+        let origin = match request.headers().get_one("Origin") {
+            // No Origin header: not a browser cross-origin request (native
+            // watchers, curl). CORS is not the relevant control there.
+            None => return false,
+            Some(origin) => origin,
+        };
+
+        if !is_extension_origin(origin) || self.user_allowed(origin) {
+            return false;
+        }
+
+        let method = match effective_method(request) {
+            // A preflight without Access-Control-Request-Method tells us
+            // nothing about the real request; fail closed.
+            None => return true,
+            Some(method) => method,
+        };
+        let segments: Vec<&str> = request.uri().path().segments().collect();
+        !is_watcher_endpoint(method, &segments)
+    }
+}
+
+/// Origins matched by the built-in `moz-extension://.*` wildcard.
+fn is_extension_origin(origin: &str) -> bool {
+    origin
+        .to_ascii_lowercase()
+        .starts_with(EXTENSION_ORIGIN_SCHEME)
+}
+
+/// The method the browser will actually use: for a preflight that is the
+/// `Access-Control-Request-Method` header, not `OPTIONS`.
+fn effective_method(request: &Request) -> Option<Method> {
+    if request.method() == Method::Options {
+        request
+            .headers()
+            .get_one("Access-Control-Request-Method")
+            .and_then(|m| m.parse::<Method>().ok())
+    } else {
+        Some(request.method())
+    }
+}
+
+/// The endpoints `aw-watcher-web` needs, as decoded path segments.
+fn is_watcher_endpoint(method: Method, segments: &[&str]) -> bool {
+    matches!(
+        (method, segments),
+        (Method::Get, ["api", "0", "info"])
+            | (Method::Post, ["api", "0", "buckets", _])
+            | (Method::Post, ["api", "0", "buckets", _, "heartbeat"])
+    )
+}
+
+/// Route handler returning 403 for out-of-scope extension requests.
+#[derive(Clone)]
+struct FairingErrorRoute {}
+
+#[rocket::async_trait]
+impl rocket::route::Handler for FairingErrorRoute {
+    async fn handle<'r>(&self, request: &'r Request<'_>, _: Data<'r>) -> Outcome<'r> {
+        let err = HttpErrorJson::new(
+            Status::Forbidden,
+            "This endpoint is not available to browser extension origins. \
+             Add the origin to 'cors_regex' in config.toml to allow it."
+                .to_string(),
+        );
+        Outcome::from(request, err)
+    }
+}
+
+fn fairing_route() -> Route {
+    Route::ranked(1, Method::Get, "/", FairingErrorRoute {})
+}
+
+fn redirect_forbidden(request: &mut Request) {
+    let uri = FAIRING_ROUTE_BASE.to_string();
+    let origin = Origin::parse_owned(uri).unwrap();
+    request.set_method(Method::Get);
+    request.set_uri(origin);
+}
+
+#[rocket::async_trait]
+impl Fairing for ExtensionCorsScope {
+    fn info(&self) -> rocket::fairing::Info {
+        rocket::fairing::Info {
+            name: "ExtensionCorsScope",
+            kind: rocket::fairing::Kind::Ignite
+                | rocket::fairing::Kind::Request
+                | rocket::fairing::Kind::Response,
+        }
+    }
+
+    async fn on_ignite(&self, rocket: Rocket<rocket::Build>) -> rocket::fairing::Result {
+        Ok(rocket.mount(FAIRING_ROUTE_BASE, vec![fairing_route()]))
+    }
+
+    async fn on_request(&self, request: &mut Request<'_>, _: &mut Data<'_>) {
+        // Preflights are answered by rocket_cors; on_response strips the
+        // CORS headers so the browser rejects the preflight itself.
+        if request.method() == Method::Options {
+            return;
+        }
+        if self.is_blocked(request) {
+            debug!(
+                "Blocking extension origin {:?} from {}",
+                request.headers().get_one("Origin"),
+                request.uri()
+            );
+            redirect_forbidden(request);
+        }
+    }
+
+    async fn on_response<'r>(&self, request: &'r Request<'_>, response: &mut Response<'r>) {
+        if self.is_blocked(request) {
+            for header in CORS_HEADERS {
+                response.remove_header(header);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rocket::http::{ContentType, Header, Status};
+    use rocket::local::blocking::Client;
+    use rocket::Rocket;
+
+    use crate::config::AWConfig;
+    use crate::endpoints;
+
+    const EXT_ORIGIN: &str = "moz-extension://3f2b1c9d-dead-beef-cafe-000000000000";
+    const WEBUI_ORIGIN: &str = "http://127.0.0.1:5600";
+
+    fn setup_testserver(cors_regex: Vec<String>) -> Rocket<rocket::Build> {
+        let state = endpoints::ServerState {
+            datastore: aw_datastore::Datastore::new_in_memory(false),
+            asset_resolver: endpoints::AssetResolver::new(None),
+            device_id: "test_id".to_string(),
+        };
+        let mut aw_config = AWConfig::default();
+        // Pin the port: the default is derived from a mutable global that other
+        // tests flip via create_config(), which would otherwise make the
+        // allowed webui origin depend on test execution order.
+        aw_config.port = 5600;
+        aw_config.cors_regex = cors_regex;
+        endpoints::build_rocket(state, aw_config)
+    }
+
+    fn client() -> Client {
+        Client::tracked(setup_testserver(vec![])).expect("valid instance")
+    }
+
+    fn allow_origin(res: &rocket::local::blocking::LocalResponse) -> Option<String> {
+        res.headers()
+            .get_one("Access-Control-Allow-Origin")
+            .map(str::to_string)
+    }
+
+    /// The reported exfiltration path: an extension reading the full export.
+    #[test]
+    fn test_extension_origin_blocked_from_export() {
+        let client = client();
+        let res = client
+            .get("/api/0/export")
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new("Origin", EXT_ORIGIN))
+            .dispatch();
+        assert_eq!(res.status(), Status::Forbidden);
+        assert_eq!(allow_origin(&res), None, "export readable by any extension");
+    }
+
+    /// The other half of the report: writing events through /api/0/import.
+    #[test]
+    fn test_extension_origin_blocked_from_import_preflight() {
+        let client = client();
+        let res = client
+            .options("/api/0/import")
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new("Origin", EXT_ORIGIN))
+            .header(Header::new("Access-Control-Request-Method", "POST"))
+            .header(Header::new(
+                "Access-Control-Request-Headers",
+                "content-type",
+            ))
+            .dispatch();
+        assert_eq!(allow_origin(&res), None, "import preflight still allowed");
+        assert_eq!(res.headers().get_one("Access-Control-Allow-Methods"), None);
+    }
+
+    /// Everything aw-watcher-web needs must keep working, unchanged.
+    #[test]
+    fn test_watcher_endpoints_still_allowed() {
+        let client = client();
+
+        let res = client
+            .get("/api/0/info")
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new("Origin", EXT_ORIGIN))
+            .dispatch();
+        assert_eq!(res.status(), Status::Ok);
+        assert_eq!(allow_origin(&res).as_deref(), Some(EXT_ORIGIN));
+
+        let res = client
+            .post("/api/0/buckets/aw-watcher-web-firefox_testhost")
+            .header(ContentType::JSON)
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new("Origin", EXT_ORIGIN))
+            .body(r#"{"type":"web.tab.current","client":"aw-client-web","hostname":"testhost"}"#)
+            .dispatch();
+        assert_ne!(res.status(), Status::Forbidden, "ensureBucket blocked");
+        assert_eq!(allow_origin(&res).as_deref(), Some(EXT_ORIGIN));
+
+        let res = client
+            .post("/api/0/buckets/aw-watcher-web-firefox_testhost/heartbeat?pulsetime=60")
+            .header(ContentType::JSON)
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new("Origin", EXT_ORIGIN))
+            .body(
+                r#"{"timestamp":"2026-07-28T09:00:00+00:00","duration":0,
+                    "data":{"url":"https://example.com","title":"Example","audible":false,
+                    "incognito":false,"tabCount":1}}"#,
+            )
+            .dispatch();
+        assert_eq!(res.status(), Status::Ok, "heartbeat blocked");
+        assert_eq!(allow_origin(&res).as_deref(), Some(EXT_ORIGIN));
+    }
+
+    /// Preflight for a watcher endpoint must still succeed — aw-client-js
+    /// sends JSON, which is always preflighted.
+    #[test]
+    fn test_watcher_preflight_still_allowed() {
+        let client = client();
+        let res = client
+            .options("/api/0/buckets/aw-watcher-web-firefox_testhost/heartbeat")
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new("Origin", EXT_ORIGIN))
+            .header(Header::new("Access-Control-Request-Method", "POST"))
+            .header(Header::new(
+                "Access-Control-Request-Headers",
+                "content-type",
+            ))
+            .dispatch();
+        assert_eq!(allow_origin(&res).as_deref(), Some(EXT_ORIGIN));
+    }
+
+    /// Scoping is per (method, path): the bucket path is writable for create,
+    /// but must not become a deletion or read channel.
+    #[test]
+    fn test_bucket_path_scoped_by_method() {
+        let client = client();
+
+        let res = client
+            .delete("/api/0/buckets/aw-watcher-web-firefox_testhost")
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new("Origin", EXT_ORIGIN))
+            .dispatch();
+        assert_eq!(res.status(), Status::Forbidden, "bucket deletable");
+
+        let res = client
+            .get("/api/0/buckets/aw-watcher-web-firefox_testhost/events")
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new("Origin", EXT_ORIGIN))
+            .dispatch();
+        assert_eq!(res.status(), Status::Forbidden, "events readable");
+    }
+
+    /// Same desync bug class as #588/#636: matching the raw path string would
+    /// let an encoded spelling reach the handler while skipping this gate.
+    #[test]
+    fn test_encoded_paths_do_not_bypass_scope() {
+        let client = client();
+        for path in [
+            "/%61pi/0/export",      // encoded 'a' in /api/
+            "/api/0/%65xport",      // encoded 'e' in /export
+            "//api/0/export",       // #588 double-slash trick
+            "/%61pi/0/%65xport",    // both
+            "/api/0/info/../query", // dot-segment
+        ] {
+            let res = client
+                .get(path)
+                .header(Header::new("Host", "localhost:5600"))
+                .header(Header::new("Origin", EXT_ORIGIN))
+                .dispatch();
+            assert_eq!(
+                res.status(),
+                Status::Forbidden,
+                "extension scope bypassed via {path}"
+            );
+            assert_eq!(allow_origin(&res), None, "CORS header leaked for {path}");
+        }
+
+        // Sanity check: these paths really do reach the export handler without
+        // an extension Origin, so the 403s above are this gate rejecting them
+        // rather than the router failing to match.
+        for path in ["/%61pi/0/export", "//api/0/export", "/api/0/%65xport"] {
+            let res = client
+                .get(path)
+                .header(Header::new("Host", "localhost:5600"))
+                .dispatch();
+            assert_eq!(
+                res.status(),
+                Status::Ok,
+                "{path} does not reach the handler"
+            );
+        }
+    }
+
+    /// Non-extension origins are untouched — the webui is same-origin and
+    /// still needs full access.
+    #[test]
+    fn test_webui_origin_unaffected() {
+        let client = client();
+        let res = client
+            .get("/api/0/export")
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new("Origin", WEBUI_ORIGIN))
+            .dispatch();
+        assert_eq!(res.status(), Status::Ok);
+        assert_eq!(allow_origin(&res).as_deref(), Some(WEBUI_ORIGIN));
+    }
+
+    /// Native clients send no Origin header and must be unaffected.
+    #[test]
+    fn test_no_origin_unaffected() {
+        let client = client();
+        let res = client
+            .get("/api/0/export")
+            .header(Header::new("Host", "localhost:5600"))
+            .dispatch();
+        assert_eq!(res.status(), Status::Ok);
+    }
+
+    /// An explicit `cors_regex` entry is a deliberate opt-in and keeps full
+    /// access — but only for the origins it actually matches.
+    #[test]
+    fn test_user_regex_allowlist_scoped_to_match() {
+        let server = setup_testserver(vec![format!("^{EXT_ORIGIN}$")]);
+        let client = Client::tracked(server).expect("valid instance");
+
+        let res = client
+            .get("/api/0/export")
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new("Origin", EXT_ORIGIN))
+            .dispatch();
+        assert_eq!(res.status(), Status::Ok);
+
+        // A different extension is still scoped.
+        let res = client
+            .get("/api/0/export")
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new(
+                "Origin",
+                "moz-extension://00000000-0000-0000-0000-999999999999",
+            ))
+            .dispatch();
+        assert_eq!(res.status(), Status::Forbidden);
+    }
+
+    /// A preflight that hides its real method must not pass.
+    #[test]
+    fn test_preflight_without_request_method_is_blocked() {
+        let client = client();
+        let res = client
+            .options("/api/0/buckets/some-bucket")
+            .header(Header::new("Host", "localhost:5600"))
+            .header(Header::new("Origin", EXT_ORIGIN))
+            .dispatch();
+        assert_eq!(allow_origin(&res), None);
+    }
+}

--- a/aw-server/src/endpoints/mod.rs
+++ b/aw-server/src/endpoints/mod.rs
@@ -53,6 +53,7 @@ mod apikey;
 mod bucket;
 mod cors;
 mod export;
+mod extension_cors;
 mod hostcheck;
 mod import;
 mod query;
@@ -137,12 +138,16 @@ pub fn build_rocket(server_state: ServerState, config: AWConfig) -> rocket::Rock
         config.address, config.port
     );
     let cors = cors::cors(&config);
+    let extension_cors = extension_cors::ExtensionCorsScope::new(&config);
     let hostcheck = hostcheck::HostCheck::new(&config);
     let apikey = apikey::ApiKeyCheck::new(&config);
     let custom_static = config.custom_static.clone();
 
     let mut rocket = rocket::custom(config.to_rocket_config())
         .attach(cors.clone())
+        // Attached before the other request fairings so a blocked extension
+        // request is rewritten to the 403 route before they inspect the path.
+        .attach(extension_cors)
         .attach(hostcheck)
         .attach(apikey)
         .manage(cors)


### PR DESCRIPTION
Reported privately by **pal0x**, who also found the api_key bypass fixed in #636. Erik cleared this for public disclosure.

## The problem

Both servers trust *every* Firefox extension origin unconditionally:

- `aw-server-rust/aw-server/src/endpoints/cors.rs` — `"moz-extension://.*"`
- `aw-server/aw_server/server.py` — `cors_origins.append("moz-extension://*")`

The wildcard exists for a real reason: Firefox gives every install of every extension its own random origin, so `aw-watcher-web` cannot be allowlisted up front. The cost is that **any installed extension can read the full local export and write events** — with no host permission, so no install-time prompt ever names ActivityWatch.

Confirmed in Firefox 152 with a temporary MV2 extension declaring only `"permissions": ["storage"]`:

```
ext=A-nohost  aw_read=200  aw_write=200
```

`aw_read` = `GET /api/0/export`, `aw_write` = `POST /api/0/buckets/<id>`.

## Why the obvious fix does not work

The natural fix is to delete the wildcard and let the official watcher through on its declared host permissions (`http://127.0.0.1:5600/api/*`, `:5666/api/*`). **This is false, and it silently breaks `aw-watcher-web`.**

Tested: same extension, same browser session, permissions confirmed granted at runtime via `browser.permissions.getAll()`, against a mock server where the *only* variable is the ACAO header:

```
origins        = http://127.0.0.1:5699/* http://127.0.0.1:5698/*   <- granted
mock_no_acao   = CORS_ERR    <- mock endpoint, no ACAO header
mock_with_acao = 200         <- same mock, same path shape, ACAO present
awserver       = 200         <- allowed only by the moz-extension wildcard
```

In Firefox 152 MV2 the server's `Access-Control-Allow-Origin` header is the sole gate; host permissions do not bypass it. Worth knowing before anyone ships the one-line "fix".

## What this PR does

Narrows the blanket trust instead of removing it. Wildcard-matched extension origins now reach only the three endpoints `aw-watcher-web` actually uses (`aw-client-js`: `getInfo`, `ensureBucket`, `heartbeat`):

| Method | Path |
|---|---|
| `GET` | `/api/0/info` |
| `POST` | `/api/0/buckets/<id>` |
| `POST` | `/api/0/buckets/<id>/heartbeat` |

Everything else — `/api/0/export`, `/api/0/import`, `/api/0/query`, `/api/0/settings`, event reads, bucket deletion — is closed to them. That removes the exfiltration half of the finding (app names, window titles, tab URLs, AFK data) with **no client change**.

### Accepted limitation

The `aw-watcher-web-*` prefix is a coarse scope, not an origin-to-bucket ownership boundary. Any wildcard-matched Firefox extension can still create or send heartbeats to another existing `aw-watcher-web-*` bucket, so web-bucket timeline poisoning remains possible. This is accepted for this first step: it preserves the official watcher's zero-configuration flow while blocking data exfiltration and writes into other watcher types. Eliminating the residual requires the pairing/origin-ownership protocol listed under “Not in this PR.”

Users who want to give a specific extension full access can still allowlist it via `cors_regex` in `config.toml`; explicit opt-in is exempt from the scoping. (The exact `cors` list can't hold an extension origin — `rocket_cors` rejects `moz-extension://` there as an opaque origin — so `cors_regex` is the opt-in path.)

**Enforcement is two-stage**, because CORS alone only hides *responses*:

- `on_request` rejects out-of-scope requests with 403 before they reach a handler. Without this, a "simple" cross-origin `POST` (e.g. `text/plain`) is still *sent* by the browser and executes server-side even though the response is unreadable.
- `on_response` strips the `Access-Control-*` headers so preflights fail in the browser.

Path matching uses `request.uri().path().segments()` — the same decoded segment view Rocket's router dispatches on, as in the #636 fix. A raw-string check would let `/%61pi/0/export` desynchronize this gate from the handler it protects (the #588/#636 bug class); there's a regression test for that.

## Verification

Real Firefox 152, MV2 extension with `host_permissions=[]`, probing two instances of *this* build — one with the wildcard opted in via `cors_regex` (i.e. pre-fix behaviour), one scoped. The ACAO policy is the only variable:

```
origin=moz-extension://66af0ab8-cce8-4a71-b536-2f3976d559d4 host_permissions=[]
unscoped.export=200        scoped.export=CORS_ERR
unscoped.import=200        scoped.import=CORS_ERR
unscoped.ensureBucket=200  scoped.ensureBucket=200
unscoped.heartbeat=200     scoped.heartbeat=200
```

So the watcher path keeps working in a real browser, while the reported data-exfiltration channel and writes to non-web watcher buckets are closed. The accepted same-prefix web-bucket poisoning limitation remains as documented above.

Also verified over real HTTP against a running server (`--testing --port 5699`): `GET /api/0/export` → 403 with no ACAO, `GET /%61pi/0/export` → 403, `OPTIONS /api/0/import` preflight → no CORS headers, while `POST /api/0/buckets/<id>` and the heartbeat → 200 with ACAO reflected, webui origin and no-Origin (native client) requests unaffected.

10 new tests. All of the blocking ones were confirmed to **fail** against the pre-fix build (fairing detached, same test file): 5 failed, and the 5 "still works" tests passed — tests written from the same assumption as the fix can't falsify it otherwise. `cargo test -p aw-server` green (27 unit + 14 api + 1 macro), fmt clean, no new clippy.

One incidental fix: the new tests pin `config.port`, because `AWConfig::default()`'s port comes from a mutable global that other tests flip via `create_config()` — leaving it default made a test order-dependent.

## Not in this PR

- **`aw-server` (Python) has the same wildcard** and needs the equivalent scoping.
- **Pairing / code exchange** — the real long-term fix Erik has in mind: extension POSTs its origin to `/api/0/pair/request`, server mints a short code, user approves in aw-webui, server persists `{origin, token}` and reflects ACAO for that origin only once paired. That reuses the existing api_key fairing rather than adding a second auth path, and needs matching `aw-watcher-web` work. This PR is the part that ships today without touching any client.

