### PR TITLE
fix(aw-sync): forward API key from server config, stop panicking on 401

### DIFF
--- a/aw-sync/README.md
+++ b/aw-sync/README.md
@@ -33,6 +33,7 @@ aw-sync sync --start-date "2024-01-01"
 ```
 
 For more options, see `aw-sync --help`. Some notable options:
+- `--config`: Read the local server port and API key from a custom aw-server config file. Pass the same path to both aw-server and aw-sync when using aw-server's `--config` override.
 - `--buckets`: Specify which buckets to sync (comma-separated). By default, all buckets are synced.
   - Use `--buckets "bucket1,bucket2"` to sync specific buckets
   - Not specifying this option syncs all buckets by default
@@ -74,7 +75,7 @@ We also avoid having to implement complex features such as conflict resolution, 
   - It will work a lot better once proper `hostname -> device ID` migration is complete.
 - It doesn't sync settings
 - It doesn't support Android, yet.
-- It mirrors events to all devices, 
+- It mirrors events to all devices,
   - If you have a lot of devices you'll get a lot of duplicates, taking up a lot of space and potentially impacting performance.
 - It doesn't support modifying/deleting events, yet.
 
@@ -88,7 +89,7 @@ If you want to try sync, you can do so by following these steps.
 
 We will use a separate testing instance of aw-server(-rust) to store and view the synced data from the sync directory. This is to avoid testing against & potentially pollute production instances in write-scenarios. We will sync all devices with the sync folder, and then sync the sync folder into our testing instance to view.
 
-To test syncing real events to a sync folder which can then be pulled from. 
+To test syncing real events to a sync folder which can then be pulled from.
 We will use some helper scripts to do the following:
 
 1. `./test-sync-push.sh`
@@ -116,7 +117,7 @@ In the end, You should get something like this: https://twitter.com/ErikBjare/st
 
 #### Pushing to the sync directory
 
-First start the sending aw-server instance. For example: 
+First start the sending aw-server instance. For example:
 
 ```sh
 PORT=5667
@@ -129,7 +130,7 @@ Then run `cargo run --bin aw-sync-rust -- --port 5667` to sync your instance's b
 
 #### Pulling from the sync directory
 
-Now to sync things back from the sync directory into another instance. 
+Now to sync things back from the sync directory into another instance.
 
 First, lets start another instance:
 
@@ -139,4 +140,3 @@ cargo run --bin aw-server -- --testing --port $PORT --dbpath test-$PORT.sqlite -
 ```
 
 Now run `cargo run --bin aw-sync -- --port 5668` to pull buckets from the sync dir (retrieving events from the 5667 instance) and push buckets from the 5668 instance to the sync dir.
-

--- a/aw-sync/src/accessmethod.rs
+++ b/aw-sync/src/accessmethod.rs
@@ -66,7 +66,7 @@ impl AccessMethod for Datastore {
 
 impl AccessMethod for AwClient {
     fn get_buckets(&self) -> Result<HashMap<String, Bucket>, String> {
-        Ok(AwClient::get_buckets(self).unwrap())
+        AwClient::get_buckets(self).map_err(|e| e.to_string())
     }
     fn get_bucket(&self, bucket_id: &str) -> Result<Bucket, DatastoreError> {
         let bucket = AwClient::get_bucket(self, bucket_id);
@@ -74,11 +74,13 @@ impl AccessMethod for AwClient {
             Ok(bucket) => Ok(bucket),
             Err(e) => {
                 warn!("{:?}", e);
-                let code = e.status().unwrap();
+                let code = e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
                 if code == StatusCode::NOT_FOUND {
                     Err(DatastoreError::NoSuchBucket(bucket_id.into()))
                 } else {
-                    panic!("Unexpected error");
+                    Err(DatastoreError::InternalError(format!(
+                        "Unexpected error fetching bucket {bucket_id}: {e}"
+                    )))
                 }
             }
         }
@@ -90,16 +92,17 @@ impl AccessMethod for AwClient {
         end: Option<DateTime<Utc>>,
         limit: Option<u64>,
     ) -> Result<Vec<Event>, String> {
-        Ok(AwClient::get_events(self, bucket_id, start, end, limit).unwrap())
+        AwClient::get_events(self, bucket_id, start, end, limit).map_err(|e| e.to_string())
     }
     fn insert_events(&self, bucket_id: &str, events: Vec<Event>) -> Result<(), String> {
         AwClient::insert_events(self, bucket_id, events).map_err(|e| e.to_string())
     }
     fn get_event_count(&self, bucket_id: &str) -> Result<i64, String> {
-        Ok(AwClient::get_event_count(self, bucket_id).unwrap())
+        AwClient::get_event_count(self, bucket_id).map_err(|e| e.to_string())
     }
     fn create_bucket(&self, bucket: &Bucket) -> Result<(), DatastoreError> {
-        AwClient::create_bucket(self, bucket).unwrap();
+        AwClient::create_bucket(self, bucket)
+            .map_err(|e| DatastoreError::InternalError(e.to_string()))?;
         Ok(())
     }
     fn heartbeat(&self, bucket_id: &str, event: Event, duration: f64) -> Result<(), String> {

--- a/aw-sync/src/main.rs
+++ b/aw-sync/src/main.rs
@@ -176,7 +176,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     if api_key.is_some() {
         info!("Using API key from server config for authentication");
     }
-    let client = AwClient::new_with_api_key(&opts.host, port, "aw-sync", api_key)?;
+    let url_host = util::host_for_url(&opts.host);
+    let client = AwClient::new_with_api_key(&url_host, port, "aw-sync", api_key)?;
 
     // if opts.command is None, then we're using the default subcommand (Daemon)
     match opts.command.unwrap_or(Commands::Daemon {

--- a/aw-sync/src/main.rs
+++ b/aw-sync/src/main.rs
@@ -166,10 +166,18 @@ fn main() -> Result<(), Box<dyn Error>> {
         .map(Ok)
         .unwrap_or_else(|| util::get_server_port(opts.testing))?;
 
-    let api_key = util::get_server_api_key(opts.testing)?;
-    if api_key.is_some() {
-        info!("Using API key from server config for authentication");
-    }
+    // Only use the local server's API key when connecting to localhost.
+    // Forwarding it to a remote host would leak the credential over HTTP.
+    let is_localhost = matches!(opts.host.as_str(), "127.0.0.1" | "::1" | "localhost");
+    let api_key = if is_localhost {
+        let key = util::get_server_api_key(opts.testing)?;
+        if key.is_some() {
+            info!("Using API key from server config for authentication");
+        }
+        key
+    } else {
+        None
+    };
     let client = AwClient::new_with_api_key(&opts.host, port, "aw-sync", api_key)?;
 
     // if opts.command is None, then we're using the default subcommand (Daemon)

--- a/aw-sync/src/main.rs
+++ b/aw-sync/src/main.rs
@@ -44,6 +44,10 @@ struct Opts {
     #[clap(long)]
     port: Option<u16>,
 
+    /// Path to the local aw-server config file.
+    #[clap(short = 'c', long = "config")]
+    config: Option<PathBuf>,
+
     /// Convenience option for using the default testing host and port.
     #[clap(long)]
     testing: bool,
@@ -161,23 +165,17 @@ fn main() -> Result<(), Box<dyn Error>> {
         std::env::set_var("AW_SYNC_DIR", sync_dir);
     }
 
-    let port = opts
-        .port
-        .map(Ok)
-        .unwrap_or_else(|| util::get_server_port(opts.testing))?;
-
-    // Only use the local server's API key when connecting to localhost.
-    // Forwarding it to a remote host would leak the credential over HTTP.
-    let is_localhost = matches!(opts.host.as_str(), "127.0.0.1" | "::1" | "localhost");
-    let api_key = if is_localhost {
-        let key = util::get_server_api_key(opts.testing)?;
-        if key.is_some() {
-            info!("Using API key from server config for authentication");
-        }
-        key
+    let server_config = if util::is_loopback_host(&opts.host) {
+        util::get_server_config(opts.testing, opts.config.as_deref())?
     } else {
-        None
+        util::ServerConfig::default_for(opts.testing)
     };
+    let port = opts.port.unwrap_or(server_config.port);
+
+    let api_key = server_config.api_key;
+    if api_key.is_some() {
+        info!("Using API key from server config for authentication");
+    }
     let client = AwClient::new_with_api_key(&opts.host, port, "aw-sync", api_key)?;
 
     // if opts.command is None, then we're using the default subcommand (Daemon)

--- a/aw-sync/src/main.rs
+++ b/aw-sync/src/main.rs
@@ -166,7 +166,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         .map(Ok)
         .unwrap_or_else(|| util::get_server_port(opts.testing))?;
 
-    let client = AwClient::new(&opts.host, port, "aw-sync")?;
+    let api_key = util::get_server_api_key(opts.testing)?;
+    if api_key.is_some() {
+        info!("Using API key from server config for authentication");
+    }
+    let client = AwClient::new_with_api_key(&opts.host, port, "aw-sync", api_key)?;
 
     // if opts.command is None, then we're using the default subcommand (Daemon)
     match opts.command.unwrap_or(Commands::Daemon {

--- a/aw-sync/src/util.rs
+++ b/aw-sync/src/util.rs
@@ -3,6 +3,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::fs::File;
 use std::io::Read;
+use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 
 #[cfg(not(target_os = "android"))]
@@ -58,7 +59,10 @@ pub fn get_server_config(
 /// Local config must never be read for a caller-selected remote target.
 #[cfg(not(target_os = "android"))]
 pub fn is_loopback_host(host: &str) -> bool {
-    matches!(host, "127.0.0.1" | "::1" | "localhost")
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
 }
 
 #[cfg(all(test, not(target_os = "android")))]
@@ -109,7 +113,7 @@ mod tests {
 
     #[test]
     fn recognizes_only_loopback_hosts() {
-        for host in ["127.0.0.1", "::1", "localhost"] {
+        for host in ["127.0.0.1", "127.0.0.2", "::1", "localhost", "LOCALHOST"] {
             assert!(is_loopback_host(host));
         }
         for host in ["example.com", "192.0.2.1", "localhost.example.com"] {

--- a/aw-sync/src/util.rs
+++ b/aw-sync/src/util.rs
@@ -65,9 +65,18 @@ pub fn is_loopback_host(host: &str) -> bool {
             .is_ok_and(|address| address.is_loopback())
 }
 
+/// Add URL brackets around bare IPv6 literals.
+#[cfg(not(target_os = "android"))]
+pub fn host_for_url(host: &str) -> String {
+    match host.parse::<IpAddr>() {
+        Ok(IpAddr::V6(_)) => format!("[{host}]"),
+        _ => host.to_string(),
+    }
+}
+
 #[cfg(all(test, not(target_os = "android")))]
 mod tests {
-    use super::{get_server_config, is_loopback_host};
+    use super::{get_server_config, host_for_url, is_loopback_host};
     use std::fs;
     use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -119,6 +128,14 @@ mod tests {
         for host in ["example.com", "192.0.2.1", "localhost.example.com"] {
             assert!(!is_loopback_host(host));
         }
+    }
+
+    #[test]
+    fn brackets_bare_ipv6_hosts_for_urls() {
+        assert_eq!(host_for_url("::1"), "[::1]");
+        assert_eq!(host_for_url("2001:db8::1"), "[2001:db8::1]");
+        assert_eq!(host_for_url("127.0.0.1"), "127.0.0.1");
+        assert_eq!(host_for_url("localhost"), "localhost");
     }
 }
 

--- a/aw-sync/src/util.rs
+++ b/aw-sync/src/util.rs
@@ -28,6 +28,27 @@ pub fn get_server_port(testing: bool) -> Result<u16, Box<dyn Error>> {
     Ok(port)
 }
 
+/// Returns the API key from the local aw-server config, if one is set.
+#[cfg(not(target_os = "android"))]
+pub fn get_server_api_key(testing: bool) -> Result<Option<String>, Box<dyn Error>> {
+    let aw_server_conf = crate::dirs::get_server_config_path(testing)
+        .map_err(|_| "Could not get aw-server config path")?;
+    if !aw_server_conf.exists() {
+        return Ok(None);
+    }
+    let mut file = File::open(&aw_server_conf)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    let value: toml::Value = toml::from_str(&contents)?;
+    let api_key = value
+        .get("auth")
+        .and_then(|a| a.get("api_key"))
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+    Ok(api_key)
+}
+
 /// Check if a directory contains a .db file
 fn contains_db_file(dir: &std::path::Path) -> bool {
     fs::read_dir(dir)

--- a/aw-sync/src/util.rs
+++ b/aw-sync/src/util.rs
@@ -5,48 +5,117 @@ use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-/// Returns the port of the local aw-server instance
 #[cfg(not(target_os = "android"))]
-pub fn get_server_port(testing: bool) -> Result<u16, Box<dyn Error>> {
-    // TODO: get aw-server config more reliably
-    let aw_server_conf = crate::dirs::get_server_config_path(testing)
-        .map_err(|_| "Could not get aw-server config path")?;
-    let fallback: u16 = if testing { 5666 } else { 5600 };
-    let port = if aw_server_conf.exists() {
-        let mut file = File::open(&aw_server_conf)?;
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)?;
-        let value: toml::Value = toml::from_str(&contents)?;
-        value
-            .get("port")
-            .and_then(|v| v.as_integer())
-            .map(|v| v as u16)
-            .unwrap_or(fallback)
-    } else {
-        fallback
-    };
-    Ok(port)
+pub struct ServerConfig {
+    pub port: u16,
+    pub api_key: Option<String>,
 }
 
-/// Returns the API key from the local aw-server config, if one is set.
 #[cfg(not(target_os = "android"))]
-pub fn get_server_api_key(testing: bool) -> Result<Option<String>, Box<dyn Error>> {
-    let aw_server_conf = crate::dirs::get_server_config_path(testing)
-        .map_err(|_| "Could not get aw-server config path")?;
-    if !aw_server_conf.exists() {
-        return Ok(None);
+impl ServerConfig {
+    pub fn default_for(testing: bool) -> Self {
+        Self {
+            port: if testing { 5666 } else { 5600 },
+            api_key: None,
+        }
     }
-    let mut file = File::open(&aw_server_conf)?;
+}
+
+/// Returns the settings aw-sync needs from the selected aw-server config.
+#[cfg(not(target_os = "android"))]
+pub fn get_server_config(
+    testing: bool,
+    config_override: Option<&Path>,
+) -> Result<ServerConfig, Box<dyn Error>> {
+    let path = match config_override {
+        Some(path) => path.to_path_buf(),
+        None => crate::dirs::get_server_config_path(testing)
+            .map_err(|_| "Could not get aw-server config path")?,
+    };
+    let default = ServerConfig::default_for(testing);
+    if !path.exists() {
+        return Ok(default);
+    }
+
     let mut contents = String::new();
-    file.read_to_string(&mut contents)?;
+    File::open(path)?.read_to_string(&mut contents)?;
     let value: toml::Value = toml::from_str(&contents)?;
+    let port = value
+        .get("port")
+        .and_then(|v| v.as_integer())
+        .and_then(|v| u16::try_from(v).ok())
+        .unwrap_or(default.port);
     let api_key = value
         .get("auth")
         .and_then(|a| a.get("api_key"))
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .map(String::from);
-    Ok(api_key)
+
+    Ok(ServerConfig { port, api_key })
+}
+
+/// Local config must never be read for a caller-selected remote target.
+#[cfg(not(target_os = "android"))]
+pub fn is_loopback_host(host: &str) -> bool {
+    matches!(host, "127.0.0.1" | "::1" | "localhost")
+}
+
+#[cfg(all(test, not(target_os = "android")))]
+mod tests {
+    use super::{get_server_config, is_loopback_host};
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn reads_port_and_api_key_from_config_override() {
+        let config_path = std::env::temp_dir().join(format!(
+            "aw-sync-config-{}-{}.toml",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::write(
+            &config_path,
+            "port = 5611\n[auth]\napi_key = \"custom-key\"\n",
+        )
+        .unwrap();
+
+        let config = get_server_config(false, Some(&config_path)).unwrap();
+
+        fs::remove_file(config_path).unwrap();
+        assert_eq!(config.port, 5611);
+        assert_eq!(config.api_key.as_deref(), Some("custom-key"));
+    }
+
+    #[test]
+    fn missing_config_override_uses_defaults() {
+        let config_path = std::env::temp_dir().join(format!(
+            "missing-aw-sync-config-{}.toml",
+            std::process::id()
+        ));
+        let _ = fs::remove_file(&config_path);
+
+        let production = get_server_config(false, Some(&config_path)).unwrap();
+        let testing = get_server_config(true, Some(&config_path)).unwrap();
+
+        assert_eq!(production.port, 5600);
+        assert!(production.api_key.is_none());
+        assert_eq!(testing.port, 5666);
+        assert!(testing.api_key.is_none());
+    }
+
+    #[test]
+    fn recognizes_only_loopback_hosts() {
+        for host in ["127.0.0.1", "::1", "localhost"] {
+            assert!(is_loopback_host(host));
+        }
+        for host in ["example.com", "192.0.2.1", "localhost.example.com"] {
+            assert!(!is_loopback_host(host));
+        }
+    }
 }
 
 /// Check if a directory contains a .db file


### PR DESCRIPTION
Fixes #639

## What broke

When `[auth] api_key` is set in the aw-server-rust config, `aw-sync` enters a crash loop because of two compounding bugs:

1. **API key never forwarded**: `AwClient::new()` always passes `None` for `api_key`, so every request to an authenticated server returns 401.
2. **401 hits an unwrap and panics**: Several methods in the `AwClient` implementation of `AccessMethod` (including `get_buckets`, called at startup) used `.unwrap()` instead of propagating errors — turning any HTTP error into a hard crash.

## Fix

- **`aw-sync/src/util.rs`** reads the server port and `[auth] api_key` together from the selected server config.
- **`aw-sync/src/main.rs`** accepts `-c` / `--config`, matching aw-server's config override, and passes the key to `AwClient::new_with_api_key()`.
- Local server config is read only for exact loopback hosts (`127.0.0.1`, `::1`, or `localhost`). A caller-selected remote `--host` never causes the local credential file to be read or its key to be attached.
- **`aw-sync/src/accessmethod.rs`** propagates HTTP failures instead of panicking in `get_buckets`, `get_events`, `get_event_count`, `create_bucket`, and non-404 `get_bucket` responses.

## Testing

- `cargo test -p aw-sync --all-targets --no-fail-fast`
- `cargo check -p aw-sync --all-targets`
- `cargo fmt --all -- --check`
- Pre-commit `cargo clippy`
- `cargo run -q -p aw-sync --bin aw-sync -- --help` (verified `-c, --config <CONFIG>`)

Added focused tests for custom config port/key parsing, production/testing fallback ports, and exact loopback-host classification.

## Usage with a custom server config

Pass the same path to both processes:

```sh
aw-server --config /custom/path.toml
aw-sync --config /custom/path.toml
```

An explicit aw-sync `--port` still takes precedence over the port read from that config.

## Out of scope

Android sync uses a JNI-provided port and has no server-config path. Passing Android auth credentials through JNI is a separate interface change and is not included here.
