### PR TITLE
fix(ci): remove brittle dependabot automerge PAT

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,10 +1,7 @@
 name: Dependabot Auto-merge
 
-# NOTE: `merge-me-action` still needs the bot PAT here.
-# Using `secrets.GITHUB_TOKEN` fails on `workflow_run` with
-# "Resource not accessible by integration" when the action queries
-# branch protection rules over GraphQL.
-# See: https://github.com/ridedott/merge-me-action/issues/1581
+# Run in the trusted `workflow_run` context and merge Dependabot PRs directly
+# with the repository token instead of depending on an external PAT.
 
 on:
   workflow_run:
@@ -13,6 +10,10 @@ on:
     workflows:
       # List all required workflow names here.
       - Build
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   auto_merge:
@@ -24,6 +25,37 @@ jobs:
       github.actor == 'dependabot[bot]'
 
     steps:
-      - uses: ridedott/merge-me-action@2568f177a681785a874d6e7af950eb1a0dd31123
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
-          GITHUB_TOKEN: ${{ secrets.AWBOT_GH_TOKEN }}
+          script: |
+            const pr = context.payload.workflow_run.pull_requests?.[0];
+            if (!pr) {
+              core.setFailed("No pull request found in workflow_run payload.");
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            if (pull.state !== "open") {
+              core.info(`PR #${pull.number} is already ${pull.state}; nothing to do.`);
+              return;
+            }
+
+            if (pull.draft) {
+              core.info(`PR #${pull.number} is a draft; skipping.`);
+              return;
+            }
+
+            await github.rest.pulls.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pull.number,
+              merge_method: "squash",
+              sha: context.payload.workflow_run.head_sha,
+            });
+
+            core.info(`Merged Dependabot PR #${pull.number}.`);


### PR DESCRIPTION
## Summary

Replace the expired-PAT-dependent `ridedott/merge-me-action` step with a direct, SHA-pinned `actions/github-script` merge using the trusted `workflow_run` repository token.

## Why

Run 30723138688 is the same `AWBOT_GH_TOKEN` `Bad credentials` failure tracked in #627. The triggering Dependabot PR's full Build matrix passed, so this is not a Rust or master regression.

The equivalent PAT-free workflow has already been proven in ActivityWatch/aw-webui#901: [run 30235772106](https://github.com/ActivityWatch/aw-webui/actions/runs/30235772106) successfully merged Dependabot PR #920 with the built-in token. This ports that proven implementation here instead of asking maintainers to keep rotating a PAT for a routine automation path.

## Safety

- Runs only after a successful `Build` triggered by a Dependabot `pull_request`
- Uses explicit `contents: write` and `pull-requests: write` permissions
- Re-fetches the PR and skips closed or draft PRs
- Passes the CI-tested head SHA to `pulls.merge`, so a branch update causes a conflict rather than merging unvalidated code
- Pins `actions/github-script` to the signed v9 commit SHA

## Verification

- `actionlint .github/workflows/dependabot-automerge.yml`
- YAML parse plus assertions for permissions and step shape
- `git diff --check`
- Cross-repo runtime proof: ActivityWatch/aw-webui run 30235772106

Fixes #627
