### PR TITLE
fix(aw-sync): only write $aw.sync.origin on pull, not push-staging

### DIFF
--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -194,10 +194,13 @@ fn get_or_create_sync_bucket(
     ds_to: &dyn AccessMethod,
     is_push: bool,
 ) -> Bucket {
-    let new_id = if is_push {
-        bucket_from.id.clone()
+    // On pull/import: derive the origin from $aw.sync.origin metadata (preferred) or the
+    // hostname (legacy fallback for buckets that predate the metadata field).  On push-staging
+    // the bucket keeps its original ID and we do NOT stamp $aw.sync.origin — staging copies
+    // should not look like synced-from-remote buckets.
+    let (new_id, sync_origin) = if is_push {
+        (bucket_from.id.clone(), None)
     } else {
-        // Ensure the bucket ID ends in "-synced-from-{device id}"
         let orig_bucketid = bucket_from.id.split("-synced-from-").next().unwrap();
         let fallback = serde_json::to_value(&bucket_from.hostname).unwrap();
         let origin = bucket_from
@@ -205,8 +208,12 @@ fn get_or_create_sync_bucket(
             .get("$aw.sync.origin")
             .unwrap_or(&fallback)
             .as_str()
-            .unwrap();
-        format!("{orig_bucketid}-synced-from-{origin}")
+            .unwrap()
+            .to_string();
+        (
+            format!("{orig_bucketid}-synced-from-{origin}"),
+            Some(origin),
+        )
     };
 
     match ds_to.get_bucket(new_id.as_str()) {
@@ -214,12 +221,13 @@ fn get_or_create_sync_bucket(
         Err(DatastoreError::NoSuchBucket(_)) => {
             let mut bucket_new = bucket_from.clone();
             bucket_new.id = new_id.clone();
-            // TODO: Replace sync origin with hostname/GUID and discuss how we will treat the data
-            // attributes for internal use.
-            bucket_new.data.insert(
-                "$aw.sync.origin".to_string(),
-                serde_json::json!(bucket_from.hostname),
-            );
+            // Only stamp $aw.sync.origin on pull/import.  The derived origin already handles
+            // the legacy case: hostname is used when the source bucket has no metadata field.
+            if let Some(origin) = sync_origin {
+                bucket_new
+                    .data
+                    .insert("$aw.sync.origin".to_string(), serde_json::json!(origin));
+            }
             ds_to.create_bucket(&bucket_new).unwrap();
             match ds_to.get_bucket(new_id.as_str()) {
                 Ok(bucket) => bucket,

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -227,6 +227,11 @@ fn get_or_create_sync_bucket(
                 bucket_new
                     .data
                     .insert("$aw.sync.origin".to_string(), serde_json::json!(origin));
+            } else {
+                // Push path: strip any stale $aw.sync.origin that bucket_from may carry
+                // (e.g. if it was previously imported by a pull).  Staging copies must
+                // never look like synced-from-remote buckets.
+                bucket_new.data.remove("$aw.sync.origin");
             }
             ds_to.create_bucket(&bucket_new).unwrap();
             match ds_to.get_bucket(new_id.as_str()) {

--- a/aw-sync/tests/sync.rs
+++ b/aw-sync/tests/sync.rs
@@ -167,6 +167,42 @@ mod sync_tests {
         );
     }
 
+    /// When bucket_from was previously pulled (carries $aw.sync.origin in its data), pushing it
+    /// to staging must strip the stale field so downstream devices don't trust a wrong origin.
+    #[test]
+    fn test_push_strips_stale_sync_origin() {
+        let state = init_teststate();
+
+        // Create a source bucket that already has $aw.sync.origin (simulating a
+        // previously-pulled bucket being pushed back to staging).
+        let bucket_id = "bucket-with-origin".to_string();
+        let bucket: Bucket = serde_json::from_value(serde_json::json!({
+            "id": bucket_id,
+            "type": "test",
+            "hostname": "device-0",
+            "client": "test",
+            "data": { "$aw.sync.origin": "some-other-host" }
+        }))
+        .unwrap();
+        state.ds_src.create_bucket(&bucket).unwrap();
+
+        aw_sync::sync_datastores(
+            &state.ds_src,
+            &state.ds_dest,
+            true, // is_push
+            Some("device-0"),
+            &SyncSpec::default(),
+        );
+
+        let push_buckets = state.ds_dest.get_buckets().unwrap();
+        let push_bucket = push_buckets.get(&bucket_id).expect("push bucket not found");
+        assert!(
+            !push_bucket.data.contains_key("$aw.sync.origin"),
+            "push-staging bucket must not carry stale $aw.sync.origin from a previously-pulled source, got: {:?}",
+            push_bucket.data
+        );
+    }
+
     fn check_synced_buckets_equal_to_src(all_buckets_map: &HashMap<String, (&Datastore, Bucket)>) {
         for (ds, bucket) in all_buckets_map.values() {
             if bucket.id.contains("-synced") {

--- a/aw-sync/tests/sync.rs
+++ b/aw-sync/tests/sync.rs
@@ -115,6 +115,58 @@ mod sync_tests {
         assert!(buckets_src.len() == buckets_dest.len());
     }
 
+    /// On pull (is_push=false), the destination bucket should have $aw.sync.origin set to
+    /// the source bucket's hostname.  On push (is_push=true), $aw.sync.origin must NOT be
+    /// written to the staging copy.
+    #[test]
+    fn test_sync_origin_metadata() {
+        let state = init_teststate();
+        let bucket_id = create_bucket(&state.ds_src, 0);
+
+        // --- push: staging copy must have no $aw.sync.origin ---
+        aw_sync::sync_datastores(
+            &state.ds_src,
+            &state.ds_dest,
+            true, // is_push
+            Some("device-0"),
+            &SyncSpec::default(),
+        );
+
+        let push_buckets = state.ds_dest.get_buckets().unwrap();
+        let push_bucket = push_buckets.get(&bucket_id).expect("push bucket not found");
+        assert!(
+            !push_bucket.data.contains_key("$aw.sync.origin"),
+            "push-staging bucket must not have $aw.sync.origin, got: {:?}",
+            push_bucket.data
+        );
+
+        // --- pull: imported bucket must have $aw.sync.origin set to the hostname ---
+        let ds_pull_dest = Datastore::new_in_memory(false);
+        aw_sync::sync_datastores(
+            &state.ds_src,
+            &ds_pull_dest,
+            false, // is_push (pull)
+            None,
+            &SyncSpec::default(),
+        );
+
+        let pull_buckets = ds_pull_dest.get_buckets().unwrap();
+        let pull_bucket_id = format!("{bucket_id}-synced-from-device-0");
+        let pull_bucket = pull_buckets
+            .get(&pull_bucket_id)
+            .expect("pull bucket not found");
+        let origin = pull_bucket
+            .data
+            .get("$aw.sync.origin")
+            .expect("pull bucket must have $aw.sync.origin")
+            .as_str()
+            .expect("$aw.sync.origin must be a string");
+        assert_eq!(
+            origin, "device-0",
+            "$aw.sync.origin should match source hostname"
+        );
+    }
+
     fn check_synced_buckets_equal_to_src(all_buckets_map: &HashMap<String, (&Datastore, Bucket)>) {
         for (ds, bucket) in all_buckets_map.values() {
             if bucket.id.contains("-synced") {


### PR DESCRIPTION
## Problem

`get_or_create_sync_bucket()` always wrote `$aw.sync.origin` to the destination bucket — even when `is_push=true` (staging local buckets into the sync folder). This caused staging copies to be incorrectly marked as if they were synced-from-remote buckets.

## Fix

Refactor the function to compute `(new_id, sync_origin)` together:

- **Push path**: `sync_origin = None` → destination bucket is created with its original ID and **no** `$aw.sync.origin` stamp.
- **Pull path**: `sync_origin = Some(origin)` → the derived origin (from existing `$aw.sync.origin` metadata, or hostname as legacy fallback) is written into the destination bucket.

This also handles buckets that predate the `$aw.sync.origin` field naturally: the hostname fallback is used consistently for both the ID construction and the metadata stamp, so legacy buckets are correctly annotated on their first pull.

## Testing

Added `test_sync_origin_metadata` covering both invariants:
- push: staging bucket has **no** `$aw.sync.origin`
- pull: imported bucket has `$aw.sync.origin` set to the source hostname

All 6 aw-sync tests pass.

## Related

- Issue #649: move sync provenance out of bucket ID into trustworthy bucket metadata (Stage 1)