### PR TITLE
fix(aw-sync): use atomic counter in test tmp_db to fix parallel-test path collision

### DIFF
--- a/aw-sync/tests/sync_roundtrip.rs
+++ b/aw-sync/tests/sync_roundtrip.rs
@@ -24,11 +24,18 @@ static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn tmp_db(name: &str) -> PathBuf {
     let mut p = std::env::temp_dir();
+    // Combine a per-process counter (within-run uniqueness) with a timestamp
+    // (cross-run uniqueness when the PID is reused and the counter resets to 0).
+    let ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
     p.push(format!(
-        "aw-sync-roundtrip-{}-{}-{}.db",
+        "aw-sync-roundtrip-{}-{}-{}-{}.db",
         std::process::id(),
         name,
         DB_COUNTER.fetch_add(1, Ordering::Relaxed),
+        ts,
     ));
     p
 }

--- a/aw-sync/tests/sync_roundtrip.rs
+++ b/aw-sync/tests/sync_roundtrip.rs
@@ -10,10 +10,17 @@
 ///
 /// Both copies then render in /timeline, so every event is shown twice.
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use aw_datastore::Datastore;
 use aw_models::{Bucket, BucketMetadata};
 use aw_sync::{sync_datastores, AccessMethod, SyncSpec};
+
+// Tests in this binary run in parallel. Use a monotonic counter to guarantee
+// each datastore gets a unique path even when two tests start within the same
+// clock tick (seen on macOS where SystemTime resolution can be coarser than
+// nanoseconds, causing path collisions and SQLite migration races).
+static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn tmp_db(name: &str) -> PathBuf {
     let mut p = std::env::temp_dir();
@@ -21,10 +28,7 @@ fn tmp_db(name: &str) -> PathBuf {
         "aw-sync-roundtrip-{}-{}-{}.db",
         std::process::id(),
         name,
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
+        DB_COUNTER.fetch_add(1, Ordering::Relaxed),
     ));
     p
 }


### PR DESCRIPTION
## Problem

`test_push_does_not_reexport_synced_buckets` and `test_own_data_does_not_return_via_peer` both call `round_trip()`, which calls `datastore("a-local")`, `datastore("a-export")`, etc. with the same names. Rust's test runner executes these tests in parallel.

`tmp_db()` previously built its path from:
```
aw-sync-roundtrip-<pid>-<name>-<nanoseconds>.db
```

On macOS, `SystemTime::now()` can return the same nanosecond value for two calls that happen within the same clock tick (the OS timer resolution can be coarser than 1 ns). When that happens, both parallel tests try to open the **same SQLite file**. One test runs the `v1→v2` migration (adding the `data` column to `buckets`) and the other hits it with the column already present, panicking:

```
Failed to upgrade database when adding data field to buckets:
  SqliteFailure(..., Some("duplicate column name: data"))
```

This caused an intermittent `Build` CI failure — first seen when the tests were added in #648, and again on master after #653.

## Fix

Add a process-wide `AtomicU64` counter to the path, **alongside** the existing timestamp. The two components cover different collision dimensions and neither is sufficient alone:

| Component | Unique across | Fails at |
|---|---|---|
| Counter | calls within one process | separate runs (resets to 0) |
| Timestamp | separate runs | calls within one clock tick |

The counter fixes the parallel-test collision above. The timestamp is retained because the counter resets to 0 in each new process, so a later run that draws a recycled PID could otherwise reconstruct a path left behind in `temp_dir()` by an earlier run — the cross-run case Greptile flagged on the first revision of this PR.

```rust
static DB_COUNTER: AtomicU64 = AtomicU64::new(0);

fn tmp_db(name: &str) -> PathBuf {
    let mut p = std::env::temp_dir();
    let ts = std::time::SystemTime::now()
        .duration_since(std::time::UNIX_EPOCH)
        .unwrap()
        .as_nanos();
    p.push(format!(
        "aw-sync-roundtrip-{}-{}-{}-{}.db",
        std::process::id(),
        name,
        DB_COUNTER.fetch_add(1, Ordering::Relaxed),
        ts,
    ));
    p
}
```

`tempfile::TempDir` would cover both dimensions unconditionally and self-clean; happy to switch to it if the maintainers prefer that over the added dependency.

No functional change to the tests themselves.
