### PR TITLE
ci: deny warnings in clippy (pre-commit and CI)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,4 +32,4 @@ jobs:
       with:
         components: clippy
     - name: Run clippy
-      run: cargo clippy
+      run: cargo clippy --workspace -- -D warnings

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
 
       - id: cargo-clippy
         name: cargo clippy
-        entry: cargo clippy --workspace
+        entry: cargo clippy --workspace -- -D warnings
         language: system
         types: [rust]
         pass_filenames: false

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -370,6 +370,7 @@ impl DatastoreInstance {
         Ok(())
     }
 
+    #[allow(clippy::result_unit_err)]
     pub fn ensure_legacy_import(&mut self, conn: &Connection) -> Result<bool, ()> {
         use super::legacy_import::legacy_import;
         if !self.first_init {
@@ -784,7 +785,7 @@ impl DatastoreInstance {
         };
         let endtime_filter_ns: i64 = match endtime_opt {
             Some(dt) => dt.timestamp_nanos_opt().unwrap(),
-            None => std::i64::MAX,
+            None => i64::MAX,
         };
         if starttime_filter_ns > endtime_filter_ns {
             warn!("Starttime in event query was lower than endtime!");
@@ -889,7 +890,7 @@ impl DatastoreInstance {
         };
         let endtime_filter_ns: i64 = match endtime_opt {
             Some(dt) => dt.timestamp_nanos_opt().unwrap(),
-            None => std::i64::MAX,
+            None => i64::MAX,
         };
         if starttime_filter_ns >= endtime_filter_ns {
             warn!("Endtime in event query was same or lower than starttime!");

--- a/aw-server/build.rs
+++ b/aw-server/build.rs
@@ -22,8 +22,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // Rebuild if the webui directory changes
     println!("cargo:rerun-if-env-changed=AW_WEBUI_DIR");
-    if webui_var.is_ok() {
-        println!("cargo:rerun-if-changed={}", webui_var.unwrap());
+    if let Ok(dir) = webui_var {
+        println!("cargo:rerun-if-changed={dir}");
     }
 
     Ok(())

--- a/aw-server/src/dirs.rs
+++ b/aw-server/src/dirs.rs
@@ -1,3 +1,6 @@
+// The public dir helpers use `Result<_, ()>` and are part of the crate API.
+#![allow(clippy::result_unit_err)]
+
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/aw-sync/src/lib.rs
+++ b/aw-sync/src/lib.rs
@@ -18,8 +18,6 @@ mod accessmethod;
 pub use accessmethod::AccessMethod;
 
 mod dirs;
-// Shared with the binary (main.rs); some items are only used there.
-#[allow(dead_code)]
 mod util;
 
 #[cfg(target_os = "android")]

--- a/aw-sync/src/lib.rs
+++ b/aw-sync/src/lib.rs
@@ -18,6 +18,8 @@ mod accessmethod;
 pub use accessmethod::AccessMethod;
 
 mod dirs;
+// Shared with the binary (main.rs); some items are only used there.
+#[allow(dead_code)]
 mod util;
 
 #[cfg(target_os = "android")]

--- a/aw-sync/src/main.rs
+++ b/aw-sync/src/main.rs
@@ -185,7 +185,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             Err("Sync dir must be absolute")?
         }
 
-        info!("Using sync dir: {}", &sync_dir.display());
+        info!("Using sync dir: {}", sync_dir.display());
         std::env::set_var("AW_SYNC_DIR", sync_dir);
     }
 
@@ -244,7 +244,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             {
                 let sync_dir = dirs::get_sync_dir()?;
                 if let Some(db_path) = &sync_db {
-                    info!("Using sync db: {}", &db_path.display());
+                    info!("Using sync db: {}", db_path.display());
 
                     if !db_path.is_absolute() {
                         Err("Sync db path must be absolute")?
@@ -311,7 +311,7 @@ fn daemon(
 
     let sync_dir = dirs::get_sync_dir()?;
     if let Some(db_path) = &sync_db {
-        info!("Using sync db: {}", &db_path.display());
+        info!("Using sync db: {}", db_path.display());
 
         if !db_path.is_absolute() {
             Err("Sync db path must be absolute")?

--- a/aw-sync/src/sync.rs
+++ b/aw-sync/src/sync.rs
@@ -299,7 +299,7 @@ pub fn sync_datastores(
         // of the local bucket, so /timeline renders every event twice.
         // See https://github.com/orgs/ActivityWatch/discussions/1373
         .filter(|tup| {
-            if is_synced_bucket(&tup.1) {
+            if is_synced_bucket(tup.1) {
                 debug!(" - Skipping already-synced bucket '{}'", tup.1.id);
                 false
             } else {
@@ -443,7 +443,7 @@ fn sync_one(
             if chunk.first().unwrap().timestamp != boundary_ts {
                 // Safe to pop all boundary_ts events: the `if` guard ensures at least one
                 // earlier event (with a different timestamp) remains in the chunk.
-                while chunk.last().map_or(false, |e| e.timestamp == boundary_ts) {
+                while chunk.last().is_some_and(|e| e.timestamp == boundary_ts) {
                     chunk.pop();
                 }
                 fetch_end = Some(boundary_ts);

--- a/aw-sync/src/util.rs
+++ b/aw-sync/src/util.rs
@@ -6,11 +6,15 @@ use std::io::Read;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 
+// Only used by the binary (main.rs) and the Android entrypoint, so these are
+// dead code in the plain library build.
+#[allow(dead_code)]
 pub struct ServerConfig {
     pub port: u16,
     pub api_key: Option<String>,
 }
 
+#[allow(dead_code)]
 impl ServerConfig {
     pub fn default_for(testing: bool) -> Self {
         Self {
@@ -25,6 +29,7 @@ impl ServerConfig {
 /// Also used on Android: the embedded server writes `config.toml` under
 /// `filesDir`, and `get_client()` in `android.rs` must send the same
 /// `[auth].api_key` or `/api/0/buckets` returns 401 (aw-android#247).
+#[allow(dead_code)]
 pub fn get_server_config(
     testing: bool,
     config_override: Option<&Path>,
@@ -59,6 +64,7 @@ pub fn get_server_config(
 
 /// Local config must never be read for a caller-selected remote target.
 #[cfg(not(target_os = "android"))]
+#[allow(dead_code)]
 pub fn is_loopback_host(host: &str) -> bool {
     host.eq_ignore_ascii_case("localhost")
         || host
@@ -68,6 +74,7 @@ pub fn is_loopback_host(host: &str) -> bool {
 
 /// Add URL brackets around bare IPv6 literals.
 #[cfg(not(target_os = "android"))]
+#[allow(dead_code)]
 pub fn host_for_url(host: &str) -> String {
     match host.parse::<IpAddr>() {
         Ok(IpAddr::V6(_)) => format!("[{host}]"),

--- a/aw-transform/src/sort.rs
+++ b/aw-transform/src/sort.rs
@@ -8,7 +8,7 @@ pub fn sort_by_timestamp(mut events: Vec<Event>) -> Vec<Event> {
 
 /// Sort a list of events by duration with the highest duration first
 pub fn sort_by_duration(mut events: Vec<Event>) -> Vec<Event> {
-    events.sort_by(|e1, e2| e2.duration.cmp(&e1.duration));
+    events.sort_by_key(|e| std::cmp::Reverse(e.duration));
     events
 }
 

--- a/aw-transform/src/split_url.rs
+++ b/aw-transform/src/split_url.rs
@@ -25,11 +25,8 @@ pub fn split_url_event(event: &mut Event) {
     use url::Url;
 
     let uri_str = match event.data.get("url") {
-        None => return,
-        Some(val) => match val {
-            Value::String(s) => s.clone(),
-            _ => return,
-        },
+        Some(Value::String(s)) => s.clone(),
+        _ => return,
     };
     let uri = match Url::parse(&uri_str) {
         Ok(uri) => uri,


### PR DESCRIPTION
## Summary

- Pass `-D warnings` to clippy in both the pre-commit hook (`.pre-commit-config.yaml`) and the `clippy` job in `lint.yml`, so any rustc or clippy warning fails the check instead of being silently printed.
- Fix the existing warnings that would otherwise trip the new gate immediately. All are mechanical, no behaviour changes:
  - `aw-server/build.rs`: `if let Ok(..)` instead of `is_ok()` + `unwrap()`
  - `aw-transform`: `sort_by_key(Reverse(..))`; collapsed a nested `match`
  - `aw-datastore`: `i64::MAX` instead of `std::i64::MAX`; `#[allow(clippy::result_unit_err)]` on the public `ensure_legacy_import` rather than changing its signature
  - `aw-server/src/dirs.rs`: module-level `allow(clippy::result_unit_err)` for the cfg-gated public dir helpers
  - `aw-sync`: `#[allow(dead_code)]` on `mod util` in the lib (the module is shared with the binary, where the flagged items are used); fixed a needless borrow and `map_or(false, ..)` → `is_some_and`

## Test plan

- [x] `pre-commit run cargo-clippy --all-files` passes
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo test -p aw-transform -p aw-datastore -p aw-sync` passes
- [ ] `clippy` CI job goes green on this PR