### PR TITLE
perf(transform): merge overlapping events without vector insertions

### DIFF
--- a/aw-transform/benches/bench.rs
+++ b/aw-transform/benches/bench.rs
@@ -1,5 +1,5 @@
 use chrono::Duration;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use serde_json::json;
 use serde_json::Map;
 use serde_json::Value;
@@ -50,5 +50,42 @@ fn bench_filter_period_intersect(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_filter_period_intersect);
+fn bench_union_no_overlap(c: &mut Criterion) {
+    let mut group = c.benchmark_group("union_no_overlap");
+    for n in [1_000, 8_000, 32_000] {
+        let now = chrono::Utc::now();
+        let first: Vec<_> = (0..n)
+            .map(|i| {
+                Event::new(
+                    now + Duration::seconds(i * 4 + 1),
+                    Duration::seconds(1),
+                    json_map! {"app": "foreground"},
+                )
+            })
+            .collect();
+        let second: Vec<_> = (0..n)
+            .map(|i| {
+                Event::new(
+                    now + Duration::seconds(i * 4),
+                    Duration::seconds(3),
+                    json_map! {"app": "background"},
+                )
+            })
+            .collect();
+        group.bench_function(BenchmarkId::new("overlapping", n), |b| {
+            b.iter_batched(
+                || (first.clone(), second.clone()),
+                |(a, b)| union_no_overlap(a, b),
+                BatchSize::LargeInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_filter_period_intersect,
+    bench_union_no_overlap
+);
 criterion_main!(benches);

--- a/aw-transform/src/union_no_overlap.rs
+++ b/aw-transform/src/union_no_overlap.rs
@@ -11,66 +11,66 @@ use chrono::{DateTime, Utc};
 ///   events1  |  ----     ------   -- |
 ///   result   | xxx--  xx ----xxx  -- |
 /// ```
-#[allow(clippy::collapsible_else_if)]
-pub fn union_no_overlap(events1: Vec<Event>, mut events2: Vec<Event>) -> Vec<Event> {
+pub fn union_no_overlap(events1: Vec<Event>, events2: Vec<Event>) -> Vec<Event> {
     let mut events_union: Vec<Event> = Vec::new();
-    let mut e1_i = 0;
-    let mut e2_i = 0;
-    while e1_i < events1.len() && e2_i < events2.len() {
-        let e1 = &events1[e1_i];
-        let e2 = &events2[e2_i];
+    let mut events1 = events1.into_iter().peekable();
+    let mut events2 = events2.into_iter();
+    // Keep a split remainder here instead of inserting it ahead of the entire
+    // unprocessed suffix. Each step consumes an input or emits a fragment.
+    let mut pending = events2.next();
+    while let (Some(e1), Some(e2)) = (events1.peek(), pending.as_ref()) {
         let e1_p: TimeInterval = e1.into();
         let e2_p: TimeInterval = e2.into();
 
         if e1_p.intersects(&e2_p) {
             if e1.timestamp <= e2.timestamp {
-                events_union.push(e1.clone());
-                e1_i += 1;
-
-                // If e2 continues after e1, we need to split up the event so we only get the part that comes after
-                let (_, e2_next) = split_event(e2, e1.timestamp + e1.duration);
-                if let Some(e2_next) = e2_next {
-                    events2[e2_i] = e2_next;
+                let end = e1.timestamp + e1.duration;
+                let e2_end = e2.timestamp + e2.duration;
+                if end > e2_end {
+                    // This foreground event may cover more background events.
+                    // Keep it pending until all of those have been removed.
+                    pending = events2.next();
+                    continue;
+                }
+                if e2.timestamp < end && end < e2_end {
+                    let remainder = pending.as_mut().unwrap();
+                    remainder.timestamp = end;
+                    remainder.duration = e2_end - end;
+                    remainder.id = None;
                 } else {
-                    e2_i += 1;
+                    pending = events2.next();
                 }
+                events_union.push(events1.next().unwrap());
             } else {
-                let (e2_next, e2_next2) = split_event(e2, e1.timestamp);
-                events_union.push(e2_next);
-                e2_i += 1;
-                if let Some(e2_next2) = e2_next2 {
-                    events2.insert(e2_i, e2_next2);
-                }
+                let (prefix, remainder) = split_event(pending.take().unwrap(), e1.timestamp);
+                events_union.push(prefix);
+                pending = remainder.or_else(|| events2.next());
             }
+        } else if e1.timestamp <= e2.timestamp {
+            events_union.push(events1.next().unwrap());
         } else {
-            if e1.timestamp <= e2.timestamp {
-                events_union.push(e1.clone());
-                e1_i += 1;
-            } else {
-                events_union.push(e2.clone());
-                e2_i += 1;
-            }
+            events_union.push(pending.take().unwrap());
+            pending = events2.next();
         }
     }
 
     // Now we just need to add any remaining events
-    events_union.extend(events1[e1_i..].iter().cloned());
-    events_union.extend(events2[e2_i..].iter().cloned());
+    events_union.extend(events1);
+    events_union.extend(pending);
+    events_union.extend(events2);
 
     events_union
 }
 
-fn split_event(e: &Event, timestamp: DateTime<Utc>) -> (Event, Option<Event>) {
+fn split_event(mut e: Event, timestamp: DateTime<Utc>) -> (Event, Option<Event>) {
     if e.timestamp < timestamp && timestamp < e.timestamp + e.duration {
         let e1 = Event::new(e.timestamp, timestamp - e.timestamp, e.data.clone());
-        let e2 = Event::new(
-            timestamp,
-            e.duration - (timestamp - e.timestamp),
-            e.data.clone(),
-        );
-        (e1, Some(e2))
+        e.duration -= timestamp - e.timestamp;
+        e.timestamp = timestamp;
+        e.id = None;
+        (e1, Some(e))
     } else {
-        (e.clone(), None)
+        (e, None)
     }
 }
 
@@ -79,6 +79,135 @@ fn split_event(e: &Event, timestamp: DateTime<Utc>) -> (Event, Option<Event>) {
 mod tests {
     use super::*;
     use chrono::Duration;
+
+    #[test]
+    fn union_matches_discrete_coverage_for_all_small_inputs() {
+        let now = Utc::now();
+        let events = |mask: u32, source: &str| {
+            let mut result = Vec::new();
+            let mut start = 0;
+            while start < 6 {
+                if mask & (1 << start) == 0 {
+                    start += 1;
+                    continue;
+                }
+                let mut end = start + 1;
+                while end < 6 && mask & (1 << end) != 0 {
+                    end += 1;
+                }
+                let mut data = serde_json::Map::new();
+                data.insert("source".into(), serde_json::json!(source));
+                result.push(Event::new(
+                    now + Duration::seconds(start),
+                    Duration::seconds(end - start),
+                    data,
+                ));
+                start = end;
+            }
+            result
+        };
+        for a in 0..64 {
+            for b in 0..64 {
+                let result = union_no_overlap(events(a, "a"), events(b, "b"));
+                for slot in 0..6 {
+                    let time = now + Duration::seconds(slot);
+                    let covering: Vec<_> = result
+                        .iter()
+                        .filter(|e| e.timestamp <= time && time < e.timestamp + e.duration)
+                        .collect();
+                    let expected = if a & (1 << slot) != 0 {
+                        Some("a")
+                    } else if b & (1 << slot) != 0 {
+                        Some("b")
+                    } else {
+                        None
+                    };
+                    assert_eq!(
+                        covering.len(),
+                        usize::from(expected.is_some()),
+                        "a={a}, b={b}, slot={slot}"
+                    );
+                    if let Some(source) = expected {
+                        assert_eq!(covering[0].data["source"], source);
+                    }
+                }
+                assert!(result
+                    .windows(2)
+                    .all(|pair| pair[0].timestamp + pair[0].duration <= pair[1].timestamp));
+            }
+        }
+    }
+
+    #[test]
+    fn repeated_splits_preserve_precedence_payloads_and_ids() {
+        let now = Utc::now();
+        let mut background = Event::new(now, Duration::seconds(12), serde_json::Map::new());
+        background.id = Some(99);
+        background
+            .data
+            .insert("source".into(), serde_json::json!("background"));
+        let foreground: Vec<_> = [2, 5, 8]
+            .into_iter()
+            .map(|start| {
+                let mut e = Event::new(
+                    now + Duration::seconds(start),
+                    Duration::seconds(1),
+                    serde_json::Map::new(),
+                );
+                e.id = Some(start);
+                e.data
+                    .insert("source".into(), serde_json::json!("foreground"));
+                e
+            })
+            .collect();
+        let result = union_no_overlap(foreground, vec![background]);
+        let expected = [
+            (0, 2, None),
+            (2, 1, Some(2)),
+            (3, 2, None),
+            (5, 1, Some(5)),
+            (6, 2, None),
+            (8, 1, Some(8)),
+            (9, 3, None),
+        ];
+        assert_eq!(result.len(), expected.len());
+        for (event, (start, duration, id)) in result.iter().zip(expected) {
+            assert_eq!(event.timestamp, now + Duration::seconds(start));
+            assert_eq!(event.duration, Duration::seconds(duration));
+            assert_eq!(event.id, id);
+            assert_eq!(
+                event.data["source"],
+                if id.is_some() {
+                    "foreground"
+                } else {
+                    "background"
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn empty_disjoint_and_zero_duration_events_keep_ids() {
+        let now = Utc::now();
+        let mut event = Event::new(now, Duration::zero(), serde_json::Map::new());
+        event.id = Some(12);
+        assert_eq!(
+            union_no_overlap(vec![], vec![event.clone()])[0].id,
+            Some(12)
+        );
+        assert_eq!(
+            union_no_overlap(vec![event.clone()], vec![])[0].id,
+            Some(12)
+        );
+        let mut later = event.clone();
+        later.timestamp += Duration::seconds(1);
+        later.id = Some(13);
+        let result = union_no_overlap(vec![event], vec![later]);
+        assert_eq!(
+            result.iter().map(|e| e.id).collect::<Vec<_>>(),
+            vec![Some(12), Some(13)]
+        );
+    }
 
     #[test]
     fn test_split_event() {
@@ -90,7 +219,7 @@ mod tests {
             duration: Duration::hours(2),
             data: serde_json::Map::new(),
         };
-        let (e1, e2_opt) = split_event(&e, now + td1h);
+        let (e1, e2_opt) = split_event(e.clone(), now + td1h);
         assert_eq!(e1.timestamp, now);
         assert_eq!(e1.duration, td1h);
 
@@ -99,7 +228,7 @@ mod tests {
         assert_eq!(e2.duration, td1h);
 
         // Now a test which does not lead to a split
-        let (e1, e2_opt) = split_event(&e, now);
+        let (e1, e2_opt) = split_event(e, now);
         assert_eq!(e1.timestamp, now);
         assert_eq!(e1.duration, Duration::hours(2));
         assert!(e2_opt.is_none());


### PR DESCRIPTION
`union_no_overlap` inserts split remainders into the middle of the second input vector, repeatedly shifting the unprocessed suffix. Keep one pending remainder and consume both inputs with iterators instead. Unsplit events are moved; splitting clones only the payload needed by an additional output fragment.

The foreground cursor is retained when it spans multiple background events. Exhaustive interval coverage testing exposed that the previous implementation could otherwise emit background events still covered by that foreground event.

Part of #671 (overlap merging).

Validation:
- `cargo test -p aw-transform`: 52 tests passed.
- Exhaustive coverage/precedence checks over 4,096 pairs of small timelines, plus split metadata/ID, empty-input, and zero-duration regressions.
- Added Criterion scaling cases with setup outside timing. Local optimized results: 1,000 events/input ≈96 µs; 8,000 ≈0.93 ms; 32,000 ≈4.69 ms.

Inputs retain the existing requirement to be ordered by timestamp. The merge performs O(n + m + output fragments) work, apart from payload copying for splits.
