### PR TITLE
perf(query): borrow variables for read-only function calls

### DIFF
--- a/aw-query/benches/benchmark.rs
+++ b/aw-query/benches/benchmark.rs
@@ -102,11 +102,26 @@ mod query_benchmarks {
             })
         });
     }
+
+    pub fn bench_read_only_references(c: &mut Criterion) {
+        let ds = setup_datastore();
+        create_bucket(&ds, BUCKETNAME.to_string());
+        insert_events(&ds, BUCKETNAME, 50_000);
+        let interval = TimeInterval::new_from_string(TIME_INTERVAL).unwrap();
+        let code = format!(
+            "events = query_bucket(\"testbucket\"); total = 0; {} return total;",
+            "total = total + sum_durations(events);".repeat(20)
+        );
+        c.bench_function("read-only references 50000 events", |b| {
+            b.iter(|| aw_query::query(&code, &interval, &ds).unwrap())
+        });
+    }
 }
 
 criterion_group!(
     benches,
     query_benchmarks::bench_assign,
-    query_benchmarks::bench_many_events
+    query_benchmarks::bench_many_events,
+    query_benchmarks::bench_read_only_references
 );
 criterion_main!(benches);

--- a/aw-query/src/datatype.rs
+++ b/aw-query/src/datatype.rs
@@ -24,14 +24,12 @@ pub enum DataType {
     Dict(HashMap<String, DataType>),
     #[serde(serialize_with = "serialize_function")]
     Function(String, functions::QueryFn),
+    #[serde(serialize_with = "serialize_function")]
+    ReadOnlyFunction(String, functions::ReadOnlyQueryFn),
 }
 
 #[allow(clippy::trivially_copy_pass_by_ref)]
-fn serialize_function<S>(
-    _element: &str,
-    _fun: &functions::QueryFn,
-    _serializer: S,
-) -> Result<S::Ok, S::Error>
+fn serialize_function<S, F>(_element: &str, _fun: &F, _serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -53,6 +51,7 @@ impl fmt::Debug for DataType {
             DataType::List(l) => write!(f, "List({l:?})"),
             DataType::Dict(d) => write!(f, "Dict({d:?})"),
             DataType::Function(name, _fun) => write!(f, "Function({name})"),
+            DataType::ReadOnlyFunction(name, _fun) => write!(f, "Function({name})"),
         }
     }
 }

--- a/aw-query/src/functions.rs
+++ b/aw-query/src/functions.rs
@@ -6,10 +6,13 @@ use aw_datastore::Datastore;
 pub type QueryFn =
     fn(args: Vec<DataType>, env: &VarEnv, ds: &Datastore) -> Result<DataType, QueryError>;
 
+pub type ReadOnlyQueryFn =
+    fn(args: &[&DataType], env: &VarEnv, ds: &Datastore) -> Result<DataType, QueryError>;
+
 pub fn fill_env(env: &mut VarEnv) {
     env.insert(
         "print".to_string(),
-        DataType::Function("print".to_string(), qfunctions::print),
+        DataType::ReadOnlyFunction("print".to_string(), qfunctions::print),
     );
     env.insert(
         "query_bucket".to_string(),
@@ -35,7 +38,7 @@ pub fn fill_env(env: &mut VarEnv) {
     );
     env.insert(
         "sum_durations".to_string(),
-        DataType::Function("sum_durations".to_string(), qfunctions::sum_durations),
+        DataType::ReadOnlyFunction("sum_durations".to_string(), qfunctions::sum_durations),
     );
     env.insert(
         "limit_events".to_string(),
@@ -43,7 +46,7 @@ pub fn fill_env(env: &mut VarEnv) {
     );
     env.insert(
         "contains".to_string(),
-        DataType::Function("contains".to_string(), qfunctions::contains),
+        DataType::ReadOnlyFunction("contains".to_string(), qfunctions::contains),
     );
     env.insert(
         "flood".to_string(),
@@ -126,7 +129,7 @@ mod qfunctions {
     use crate::VarEnv;
 
     pub fn print(
-        args: Vec<DataType>,
+        args: &[&DataType],
         _env: &VarEnv,
         _ds: &Datastore,
     ) -> Result<DataType, QueryError> {
@@ -236,17 +239,17 @@ mod qfunctions {
     }
 
     pub fn contains(
-        args: Vec<DataType>,
+        args: &[&DataType],
         _env: &VarEnv,
         _ds: &Datastore,
     ) -> Result<DataType, QueryError> {
         // typecheck
-        validate::args_length(&args, 2)?;
-        match args.first().unwrap() {
-            DataType::List(ref list) => Ok(DataType::Bool(list.contains(&args[1]))),
+        validate::args_length(args, 2)?;
+        match args[0] {
+            DataType::List(list) => Ok(DataType::Bool(list.contains(args[1]))),
             DataType::Dict(ref dict) => {
                 let s = match &args[1] {
-                    DataType::String(s) => s.to_string(),
+                    DataType::String(s) => s.as_str(),
                     _ => {
                         return Err(QueryError::InvalidFunctionParameters(format!(
                             "function contains got second argument {:?}, expected type String",
@@ -254,7 +257,7 @@ mod qfunctions {
                         )))
                     }
                 };
-                Ok(DataType::Bool(dict.contains_key(&s)))
+                Ok(DataType::Bool(dict.contains_key(s)))
             }
             _ => Err(QueryError::InvalidFunctionParameters(format!(
                 "function contains got first argument {:?}, expected type List or Dict",
@@ -381,18 +384,28 @@ mod qfunctions {
     }
 
     pub fn sum_durations(
-        args: Vec<DataType>,
+        args: &[&DataType],
         _env: &VarEnv,
         _ds: &Datastore,
     ) -> Result<DataType, QueryError> {
         // typecheck
-        validate::args_length(&args, 1)?;
-        let mut events: Vec<Event> = args.into_iter().next().unwrap().try_into()?;
-
-        // Sort by duration
+        validate::args_length(args, 1)?;
+        let events = match args[0] {
+            DataType::List(events) => events,
+            invalid_type => {
+                return Err(QueryError::InvalidFunctionParameters(format!(
+                    "Expected function parameter of type List, got {invalid_type:?}"
+                )))
+            }
+        };
         let mut sum_durations = chrono::Duration::zero();
-        for event in events.drain(..) {
-            sum_durations += event.duration;
+        for event in events {
+            match event {
+                DataType::Event(event) => sum_durations += event.duration,
+                invalid_type => return Err(QueryError::InvalidFunctionParameters(format!(
+                    "Expected function parameter of type List of Events, list contains {invalid_type:?}"
+                ))),
+            }
         }
         Ok(DataType::Number(
             (sum_durations.num_milliseconds() as f64) / 1000.0,
@@ -601,7 +614,7 @@ mod validate {
     use crate::{DataType, QueryError, VarEnv};
     use aw_models::TimeInterval;
 
-    pub fn args_length(args: &[DataType], len: usize) -> Result<(), QueryError> {
+    pub fn args_length<T>(args: &[T], len: usize) -> Result<(), QueryError> {
         if args.len() != len {
             return Err(QueryError::InvalidFunctionParameters(format!(
                 "Expected {} parameters in function, got {}",

--- a/aw-query/src/interpret.rs
+++ b/aw-query/src/interpret.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 use crate::functions;
 
@@ -213,6 +213,41 @@ fn interpret_expr(
             Ok(DataType::None())
         }
         Function(fname, e) => {
+            // Borrow variables only when every argument is an atom. Evaluating
+            // arbitrary arguments may assign to the environment, including the
+            // function binding itself, so those retain the owned evaluation path.
+            if let Expr_::List(exprs) = &e.node {
+                if exprs.iter().all(|expr| {
+                    matches!(
+                        expr.node,
+                        Expr_::Var(_) | Expr_::Bool(_) | Expr_::Number(_) | Expr_::String(_)
+                    )
+                }) {
+                    if let Some(DataType::ReadOnlyFunction(_, fun)) = env.get(&fname) {
+                        let args: Result<Vec<Cow<'_, DataType>>, QueryError> = exprs
+                            .iter()
+                            .map(|expr| {
+                                Ok(match &expr.node {
+                                    Expr_::Var(name) => {
+                                        Cow::Borrowed(env.get(name).ok_or_else(|| {
+                                            QueryError::VariableNotDefined(name.clone())
+                                        })?)
+                                    }
+                                    Expr_::Bool(value) => Cow::Owned(DataType::Bool(*value)),
+                                    Expr_::Number(value) => Cow::Owned(DataType::Number(*value)),
+                                    Expr_::String(value) => {
+                                        Cow::Owned(DataType::String(value.clone()))
+                                    }
+                                    _ => unreachable!(),
+                                })
+                            })
+                            .collect();
+                        let args = args?;
+                        let refs: Vec<_> = args.iter().map(|arg| arg.as_ref()).collect();
+                        return fun(&refs, env, ds);
+                    }
+                }
+            }
             let args = match interpret_expr(env, ds, *e)? {
                 DataType::List(l) => l,
                 _ => unreachable!(),
@@ -221,11 +256,14 @@ fn interpret_expr(
                 Some(v) => v,
                 None => return Err(QueryError::VariableNotDefined(fname.clone())),
             };
-            let (_name, fun) = match var {
-                DataType::Function(name, fun) => (name, fun),
-                _data => return Err(QueryError::InvalidType(fname.to_string())),
-            };
-            fun(args, env, ds)
+            match var {
+                DataType::Function(_, fun) => fun(args, env, ds),
+                DataType::ReadOnlyFunction(_, fun) => {
+                    let refs: Vec<_> = args.iter().collect();
+                    fun(&refs, env, ds)
+                }
+                _ => Err(QueryError::InvalidType(fname.to_string())),
+            }
         }
         List(list) => {
             let mut l = Vec::new();
@@ -243,5 +281,123 @@ fn interpret_expr(
             }
             Ok(DataType::Dict(dict))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(code: &str, env: &mut VarEnv, ds: &Datastore) -> DataType {
+        let program = crate::parser::parse(crate::lexer::Lexer::new(code)).unwrap();
+        for expr in program.stmts {
+            interpret_expr(env, ds, expr).unwrap();
+        }
+        env.remove("RETURN").unwrap_or(DataType::None())
+    }
+
+    #[test]
+    fn read_only_arguments_borrow_the_original_value_and_support_aliases() {
+        fn check(args: &[&DataType], env: &VarEnv, _: &Datastore) -> Result<DataType, QueryError> {
+            assert!(std::ptr::eq(args[0], env.get("events").unwrap()));
+            Ok(DataType::Bool(true))
+        }
+        let ds = Datastore::new_in_memory(false);
+        let mut env = VarEnv::new();
+        env.insert(
+            "check".into(),
+            DataType::ReadOnlyFunction("check".into(), check),
+        );
+        env.insert(
+            "events".into(),
+            DataType::List(vec![DataType::Event(aw_models::Event::default())]),
+        );
+        assert_eq!(
+            run("alias = check; return alias(events);", &mut env, &ds),
+            DataType::Bool(true)
+        );
+        assert!(env.contains_key("events"));
+    }
+
+    #[test]
+    fn side_effecting_arguments_keep_snapshots_and_resolve_the_function_after_evaluation() {
+        fn check(args: &[&DataType], env: &VarEnv, _: &Datastore) -> Result<DataType, QueryError> {
+            assert_eq!(args[0], &DataType::List(vec![DataType::Number(1.0)]));
+            assert_eq!(env["items"], DataType::List(vec![DataType::Number(2.0)]));
+            Ok(DataType::Bool(true))
+        }
+        let ds = Datastore::new_in_memory(false);
+        let mut env = VarEnv::new();
+        env.insert(
+            "check".into(),
+            DataType::ReadOnlyFunction("check".into(), check),
+        );
+        // Assignment nodes are supported by the interpreter, although the
+        // current parser only emits them at statement level.
+        let expr = |node| Expr {
+            span: crate::lexer::Span {
+                lo: 0,
+                hi: 0,
+                line: 1,
+            },
+            node,
+        };
+        for rebind in [false, true] {
+            env.insert("items".into(), DataType::List(vec![DataType::Number(1.0)]));
+            env.insert(
+                "f".into(),
+                if rebind {
+                    DataType::Number(0.0)
+                } else {
+                    env["check"].clone()
+                },
+            );
+            let mut args = vec![
+                expr(Expr_::Var("items".into())),
+                expr(Expr_::Assign(
+                    "items".into(),
+                    Box::new(expr(Expr_::List(vec![expr(Expr_::Number(2.0))]))),
+                )),
+            ];
+            if rebind {
+                args.push(expr(Expr_::Assign(
+                    "f".into(),
+                    Box::new(expr(Expr_::Var("check".into()))),
+                )));
+            }
+            let call = expr(Expr_::Function(
+                "f".into(),
+                Box::new(expr(Expr_::List(args))),
+            ));
+            assert_eq!(
+                interpret_expr(&mut env, &ds, call).unwrap(),
+                DataType::Bool(true)
+            );
+        }
+    }
+
+    #[test]
+    fn read_only_builtins_keep_values_available_and_accept_computed_arguments() {
+        let ds = Datastore::new_in_memory(false);
+        let mut env = VarEnv::new();
+        functions::fill_env(&mut env);
+        let mut event = aw_models::Event::default();
+        event.duration = chrono::Duration::seconds(3);
+        env.insert(
+            "events".into(),
+            DataType::List(vec![DataType::Event(event)]),
+        );
+        assert_eq!(run("total = sum_durations; a = total(events); b = total(events + events); return a + b;", &mut env, &ds), DataType::Number(9.0));
+        assert_eq!(
+            run(
+                "values = [1, 2]; f = contains; a = f(values, 2); return [a, values];",
+                &mut env,
+                &ds
+            ),
+            DataType::List(vec![
+                DataType::Bool(true),
+                DataType::List(vec![DataType::Number(1.0), DataType::Number(2.0)])
+            ])
+        );
     }
 }


### PR DESCRIPTION
Reading a variable for `sum_durations`, `contains`, or `print` currently deep-copies the entire value before the function can inspect it. Register these as read-only functions and borrow variable arguments when all arguments are variables or scalar literals. This also works through function aliases.

Computed arguments retain the existing owned evaluation path. Transform functions still receive independent owned values; there is no change to query syntax or variable value semantics. The fallback preserves argument evaluation order and resolves the function binding after evaluation.

Part of #671 (read-only query copies). Related background: #119, #122, #183; this is a narrow alternative to a general ownership/refcounting rewrite.

Validation:
- `cargo test -p aw-query`: 30 tests passed, including regex fuzz regressions and doc tests.
- Added pointer-identity coverage proving that a read-only callback receives the original variable, alias/reuse tests, computed-argument tests, and direct-AST evaluation-order/rebinding tests.
- Added a Criterion query workload that reads 50,000 synthetic events and sums their durations 20 times. The same benchmark on upstream `02ae248` measured approximately 118.8 ms versus 15.8 ms on this branch, including datastore retrieval. Both runs used only synthetic in-memory data.

The optimization deliberately falls back for complex argument expressions; those can be addressed separately without widening this change.
