### PR TITLE
perf(export): serialize HTTP exports with bounded event buffering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,6 +292,7 @@ dependencies = [
  "serde",
  "serde_json",
  "subtle",
+ "tempfile",
  "toml",
  "uuid",
 ]

--- a/aw-datastore/examples/export_memory.rs
+++ b/aw-datastore/examples/export_memory.rs
@@ -1,0 +1,61 @@
+//! Reproducible export-memory comparison using synthetic, in-memory data only.
+//! Build with `cargo build -p aw-datastore --example export_memory --release`.
+//! Run the resulting executable under a memory profiler with `stream 100000`
+//! or `materialized 100000`. No existing database or server is opened.
+use aw_datastore::DatastoreInstance;
+use aw_models::{Bucket, BucketMetadata, BucketsExport, TryVec};
+use chrono::Utc;
+use rusqlite::Connection;
+use std::{hint::black_box, time::Instant};
+
+fn main() {
+    let mode = std::env::args().nth(1).unwrap_or_else(|| "stream".into());
+    assert!(matches!(mode.as_str(), "stream" | "materialized"));
+    let count: u32 = std::env::args()
+        .nth(2)
+        .unwrap_or_else(|| "100000".into())
+        .parse()
+        .unwrap();
+    let conn = Connection::open_in_memory().unwrap();
+    let mut ds = DatastoreInstance::new(&conn, true).unwrap();
+    ds.create_bucket(
+        &conn,
+        Bucket {
+            bid: None,
+            id: "synthetic".into(),
+            _type: "test".into(),
+            client: "test".into(),
+            hostname: "test".into(),
+            created: Some(Utc::now()),
+            data: Default::default(),
+            metadata: BucketMetadata::default(),
+            events: None,
+            last_updated: None,
+        },
+    )
+    .unwrap();
+    let payload = serde_json::json!({"app": "browser", "title": "x".repeat(256)}).to_string();
+    conn.execute(
+        "WITH RECURSIVE seq(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM seq WHERE n<?1)
+        INSERT INTO events(bucketrow,starttime,endtime,data)
+        SELECT 1,n*1000000000,n*1000000000+500000000,?2 FROM seq",
+        rusqlite::params![count, payload],
+    )
+    .unwrap();
+    let mut ds = DatastoreInstance::new(&conn, true).unwrap();
+    let start = Instant::now();
+    if mode == "stream" {
+        ds.write_export(&conn, None, std::io::sink()).unwrap();
+    } else {
+        let mut buckets = ds.get_buckets();
+        for (id, bucket) in &mut buckets {
+            bucket.events = Some(TryVec::new(
+                ds.get_events(&conn, id, None, None, None).unwrap(),
+            ));
+        }
+        let export = BucketsExport { buckets };
+        let body = serde_json::to_string(&export).unwrap();
+        black_box((&export, &body));
+    }
+    println!("{mode}: {count} synthetic events, {:?}", start.elapsed());
+}

--- a/aw-datastore/src/datastore.rs
+++ b/aw-datastore/src/datastore.rs
@@ -217,7 +217,10 @@ pub struct DatastoreInstance {
 ///
 /// When `clip` is set to `(starttime_filter_ns, endtime_filter_ns)`, the event is
 /// clamped to that query range.
-fn parse_event_row(row: &rusqlite::Row, clip: Option<(i64, i64)>) -> rusqlite::Result<Event> {
+pub(crate) fn parse_event_row(
+    row: &rusqlite::Row,
+    clip: Option<(i64, i64)>,
+) -> rusqlite::Result<Event> {
     let id = row.get(0)?;
     let mut starttime_ns: i64 = row.get(1)?;
     let mut endtime_ns: i64 = row.get(2)?;
@@ -489,6 +492,21 @@ impl DatastoreInstance {
 
     pub fn get_buckets(&self) -> HashMap<String, Bucket> {
         self.buckets_cache.clone()
+    }
+
+    /// Serialize an export one event at a time using the caller's connection.
+    /// Returns the bucket ID for a single-bucket export (for download naming).
+    pub fn write_export(
+        &self,
+        conn: &Connection,
+        bucket_id: Option<&str>,
+        writer: impl std::io::Write,
+    ) -> Result<Option<String>, DatastoreError> {
+        crate::export::write_export(conn, &self.buckets_cache, bucket_id, writer)?;
+        Ok(bucket_id.map(str::to_owned).or_else(|| {
+            (self.buckets_cache.len() == 1)
+                .then(|| self.buckets_cache.keys().next().unwrap().clone())
+        }))
     }
 
     pub fn insert_events(

--- a/aw-datastore/src/export.rs
+++ b/aw-datastore/src/export.rs
@@ -1,0 +1,220 @@
+use std::{collections::HashMap, io::Write};
+
+use aw_models::Bucket;
+use rusqlite::Connection;
+use serde::{
+    ser::{Error, SerializeMap, SerializeSeq},
+    Serialize, Serializer,
+};
+
+use crate::DatastoreError;
+
+struct EventRows<'a> {
+    conn: &'a Connection,
+    bucket: &'a Bucket,
+}
+
+impl Serialize for EventRows<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut stmt = self
+            .conn
+            .prepare_cached(
+                "SELECT id, starttime, endtime, data
+             FROM events INDEXED BY events_bucketrow_starttime_endtime_index
+             WHERE bucketrow = ?1 AND endtime >= 0 AND starttime <= ?2
+             ORDER BY starttime DESC, endtime ASC, id ASC",
+            )
+            .map_err(S::Error::custom)?;
+        let mut rows = stmt
+            .query(rusqlite::params![self.bucket.bid.unwrap(), i64::MAX])
+            .map_err(S::Error::custom)?;
+        let mut seq = serializer.serialize_seq(None)?;
+        while let Some(row) = rows.next().map_err(S::Error::custom)? {
+            // Match get_events' default range, clipping and corrupt-row policy.
+            match crate::datastore::parse_event_row(row, Some((0, i64::MAX))) {
+                Ok(event) => seq.serialize_element(&event)?,
+                Err(err) => warn!("Corrupt event in bucket {}: {}", self.bucket.id, err),
+            }
+        }
+        seq.end()
+    }
+}
+
+struct ExportBucket<'a> {
+    conn: &'a Connection,
+    bucket: &'a Bucket,
+}
+
+impl Serialize for ExportBucket<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // Reuse Bucket's field names and serialization rules, replacing only
+        // events. This allocation contains bucket metadata, never event rows.
+        let metadata = serde_json::to_value(self.bucket).map_err(S::Error::custom)?;
+        let metadata = metadata
+            .as_object()
+            .ok_or_else(|| S::Error::custom("invalid bucket metadata"))?;
+        let mut map = serializer.serialize_map(Some(metadata.len()))?;
+        for (key, value) in metadata {
+            if key != "events" {
+                map.serialize_entry(key, value)?;
+            }
+        }
+        map.serialize_entry(
+            "events",
+            &EventRows {
+                conn: self.conn,
+                bucket: self.bucket,
+            },
+        )?;
+        map.end()
+    }
+}
+
+struct ExportBuckets<'a> {
+    conn: &'a Connection,
+    buckets: &'a HashMap<String, Bucket>,
+    selected: Option<&'a str>,
+}
+
+impl Serialize for ExportBuckets<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        for (id, bucket) in self.buckets {
+            if self.selected.is_none() || self.selected == Some(id.as_str()) {
+                map.serialize_entry(
+                    id,
+                    &ExportBucket {
+                        conn: self.conn,
+                        bucket,
+                    },
+                )?;
+            }
+        }
+        map.end()
+    }
+}
+
+pub(crate) fn write_export(
+    conn: &Connection,
+    buckets: &HashMap<String, Bucket>,
+    selected: Option<&str>,
+    writer: impl Write,
+) -> Result<(), DatastoreError> {
+    if let Some(id) = selected {
+        if !buckets.contains_key(id) {
+            return Err(DatastoreError::NoSuchBucket(id.to_owned()));
+        }
+    }
+    #[derive(Serialize)]
+    struct Export<'a> {
+        buckets: ExportBuckets<'a>,
+    }
+    serde_json::to_writer(
+        writer,
+        &Export {
+            buckets: ExportBuckets {
+                conn,
+                buckets,
+                selected,
+            },
+        },
+    )
+    .map_err(|err| DatastoreError::InternalError(format!("Failed to write export: {err}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DatastoreInstance;
+    use aw_models::{BucketMetadata, BucketsExport, Event, TryVec};
+    use chrono::{DateTime, Duration};
+
+    fn setup() -> (Connection, DatastoreInstance) {
+        let conn = Connection::open_in_memory().unwrap();
+        let mut ds = DatastoreInstance::new(&conn, true).unwrap();
+        for id in ["populated", "empty"] {
+            ds.create_bucket(
+                &conn,
+                Bucket {
+                    bid: None,
+                    id: id.into(),
+                    _type: "test".into(),
+                    client: "test".into(),
+                    hostname: "host".into(),
+                    created: None,
+                    data: Default::default(),
+                    metadata: BucketMetadata::default(),
+                    events: None,
+                    last_updated: None,
+                },
+            )
+            .unwrap();
+        }
+        let events = [(-10, 20), (5, 20), (5, 10), (5, 10), (30, 0)]
+            .into_iter()
+            .map(|(start, duration)| {
+                Event::new(
+                    DateTime::from_timestamp(start, 0).unwrap(),
+                    Duration::seconds(duration),
+                    serde_json::from_value(
+                        serde_json::json!({"text": "quotes \" and unicode ☀", "nested": [1, true]}),
+                    )
+                    .unwrap(),
+                )
+            })
+            .collect();
+        ds.insert_events(&conn, "populated", events).unwrap();
+        conn.execute("INSERT INTO events(bucketrow,starttime,endtime,data) VALUES(1,6000000000,7000000000,'invalid json')", []).unwrap();
+        (conn, ds)
+    }
+
+    #[test]
+    fn streamed_json_matches_materialized_exports() {
+        let (conn, mut ds) = setup();
+        for selected in [None, Some("populated"), Some("empty")] {
+            let mut buckets = ds.get_buckets();
+            buckets.retain(|id, _| selected.is_none() || selected == Some(id.as_str()));
+            for (id, bucket) in &mut buckets {
+                bucket.events = Some(TryVec::new(
+                    ds.get_events(&conn, id, None, None, None).unwrap(),
+                ));
+            }
+            let expected = serde_json::to_value(BucketsExport { buckets }).unwrap();
+            let mut output = Vec::new();
+            ds.write_export(&conn, selected, &mut output).unwrap();
+            assert_eq!(
+                serde_json::from_slice::<serde_json::Value>(&output).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn missing_bucket_and_writer_failures_propagate() {
+        let (conn, ds) = setup();
+        let mut output = Vec::new();
+        assert!(matches!(
+            ds.write_export(&conn, Some("missing"), &mut output),
+            Err(DatastoreError::NoSuchBucket(_))
+        ));
+        assert!(output.is_empty());
+        struct FailingWriter(usize);
+        impl Write for FailingWriter {
+            fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+                if self.0 == 0 {
+                    return Err(std::io::Error::new(std::io::ErrorKind::Other, "disk full"));
+                }
+                let n = bytes.len().min(self.0);
+                self.0 -= n;
+                Ok(n)
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        assert!(matches!(
+            ds.write_export(&conn, None, FailingWriter(500)),
+            Err(DatastoreError::InternalError(_))
+        ));
+    }
+}

--- a/aw-datastore/src/lib.rs
+++ b/aw-datastore/src/lib.rs
@@ -18,6 +18,7 @@ macro_rules! json_map {
 }
 
 mod datastore;
+mod export;
 mod legacy_import;
 mod privacy_filter;
 mod worker;

--- a/aw-datastore/src/worker.rs
+++ b/aw-datastore/src/worker.rs
@@ -1,6 +1,10 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::thread;
+use std::{
+    fs::File,
+    io::{BufWriter, Write},
+};
 
 use chrono::DateTime;
 use chrono::Duration;
@@ -41,8 +45,9 @@ impl fmt::Debug for Datastore {
  */
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum Response {
+    Export(File, Option<String>),
     Empty(),
     Bucket(Bucket),
     BucketMap(HashMap<String, Bucket>),
@@ -54,8 +59,9 @@ pub enum Response {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum Command {
+    Export(Option<String>, File),
     CreateBucket(Bucket),
     DeleteBucket(String),
     GetBucket(String),
@@ -284,6 +290,15 @@ impl DatastoreWorker {
         tx: &Transaction,
     ) -> Result<Response, DatastoreError> {
         match request {
+            Command::Export(bucket_id, mut file) => {
+                let mut writer = BufWriter::new(&mut file);
+                let name = ds.write_export(tx, bucket_id.as_deref(), &mut writer)?;
+                writer.flush().map_err(|err| {
+                    DatastoreError::InternalError(format!("Failed to flush export: {err}"))
+                })?;
+                drop(writer);
+                Ok(Response::Export(file, name))
+            }
             Command::CreateBucket(bucket) => match ds.create_bucket(tx, bucket) {
                 Ok(_) => {
                     self.commit = true;
@@ -521,6 +536,20 @@ impl Datastore {
             e => Err(DatastoreError::InternalError(format!(
                 "Invalid response: {e:?}"
             ))),
+        }
+    }
+
+    /// Write a consistent export to an empty temporary file. The file is
+    /// returned only after serialization and flushing succeed. Event rows are
+    /// serialized individually, including this worker's uncommitted writes.
+    pub fn export_to_file(
+        &self,
+        bucket_id: Option<&str>,
+        file: File,
+    ) -> Result<(File, Option<String>), DatastoreError> {
+        match self.request(Command::Export(bucket_id.map(str::to_owned), file))? {
+            Response::Export(file, name) => Ok((file, name)),
+            _ => panic!("Invalid response"),
         }
     }
 

--- a/aw-server/Cargo.toml
+++ b/aw-server/Cargo.toml
@@ -40,6 +40,7 @@ uuid = { version = "1.3", features = ["serde", "v4"] }
 clap = { version = "4.1", features = ["derive", "cargo"] }
 log-panics = { version = "2", features = ["with-backtrace"]}
 subtle = "2"
+tempfile = "3"
 rust-embed = { version = "8.0.0", features = ["interpolate-folder-path", "debug-embed"] }
 aw-datastore = { path = "../aw-datastore", default-features = false }
 aw-models = { path = "../aw-models" }

--- a/aw-server/src/endpoints/bucket.rs
+++ b/aw-server/src/endpoints/bucket.rs
@@ -8,9 +8,7 @@ use chrono::Utc;
 
 use aw_datastore::DatastoreError;
 use aw_models::Bucket;
-use aw_models::BucketsExport;
 use aw_models::Event;
-use aw_models::TryVec;
 
 use rocket::http::Status;
 use rocket::State;
@@ -222,16 +220,7 @@ pub fn bucket_export(
     bucket_id: &str,
     state: &State<ServerState>,
 ) -> Result<BucketsExportRocket, HttpErrorJson> {
-    let datastore = &state.datastore;
-    let mut export = BucketsExport {
-        buckets: HashMap::new(),
-    };
-    let mut bucket = datastore.get_bucket(bucket_id)?;
-    let events = datastore.get_events(bucket_id, None, None, None)?;
-    bucket.events = Some(TryVec::new(events));
-    export.buckets.insert(bucket_id.into(), bucket);
-
-    Ok(export.into())
+    BucketsExportRocket::new(&state.datastore, Some(bucket_id))
 }
 
 #[delete("/<bucket_id>")]

--- a/aw-server/src/endpoints/export.rs
+++ b/aw-server/src/endpoints/export.rs
@@ -1,25 +1,9 @@
-use std::collections::HashMap;
-
 use rocket::State;
-
-use aw_models::BucketsExport;
-use aw_models::TryVec;
 
 use crate::endpoints::util::BucketsExportRocket;
 use crate::endpoints::{HttpErrorJson, ServerState};
 
 #[get("/")]
 pub fn buckets_export(state: &State<ServerState>) -> Result<BucketsExportRocket, HttpErrorJson> {
-    let datastore = &state.datastore;
-    let mut export = BucketsExport {
-        buckets: HashMap::new(),
-    };
-    let mut buckets = datastore.get_buckets()?;
-    for (bid, mut bucket) in buckets.drain() {
-        let events = datastore.get_events(&bid, None, None, None)?;
-        bucket.events = Some(TryVec::new(events));
-        export.buckets.insert(bid, bucket);
-    }
-
-    Ok(export.into())
+    BucketsExportRocket::new(&state.datastore, None)
 }

--- a/aw-server/src/endpoints/util.rs
+++ b/aw-server/src/endpoints/util.rs
@@ -1,4 +1,4 @@
-use std::io::Cursor;
+use std::io::{Cursor, Seek, SeekFrom};
 
 use rocket::http::ContentType;
 use rocket::http::Header;
@@ -6,8 +6,6 @@ use rocket::http::Status;
 use rocket::request::Request;
 use rocket::response::{self, Responder, Response};
 use serde::Serialize;
-
-use aw_models::BucketsExport;
 
 #[derive(Serialize, Debug)]
 pub struct HttpErrorJson {
@@ -40,33 +38,43 @@ impl<'r> Responder<'r, 'static> for HttpErrorJson {
 }
 
 pub struct BucketsExportRocket {
-    inner: BucketsExport,
+    file: std::fs::File,
+    filename: String,
 }
 
-impl From<BucketsExport> for BucketsExportRocket {
-    fn from(val: BucketsExport) -> Self {
-        BucketsExportRocket { inner: val }
+impl BucketsExportRocket {
+    pub fn new(
+        datastore: &aw_datastore::Datastore,
+        bucket_id: Option<&str>,
+    ) -> Result<Self, HttpErrorJson> {
+        let io_error = |err: std::io::Error| {
+            error!("Failed to prepare export file: {err}");
+            HttpErrorJson::new(
+                Status::InternalServerError,
+                "Failed to prepare export file".into(),
+            )
+        };
+        // tempfile creates a private file and removes it when the response is
+        // dropped. Spooling preserves HTTP errors even if serialization or disk
+        // writes fail, while keeping event buffering bounded.
+        let file = tempfile::tempfile().map_err(io_error)?;
+        let (mut file, name) = datastore.export_to_file(bucket_id, file)?;
+        file.seek(SeekFrom::Start(0)).map_err(io_error)?;
+        let filename = match name {
+            Some(id) => format!("attachment; filename=aw-bucket-export_{id}.json"),
+            None => "attachment; filename=aw-buckets-export.json".into(),
+        };
+        Ok(Self { file, filename })
     }
 }
 
 impl<'r> Responder<'r, 'static> for BucketsExportRocket {
     fn respond_to(self, _: &Request) -> response::Result<'static> {
-        let body = serde_json::to_string(&self.inner).map_err(|err| {
-            error!("Failed to serialize bucket export: {err}");
-            Status::InternalServerError
-        })?;
-        let header_content = match self.inner.buckets.len() == 1 {
-            true => format!(
-                "attachment; filename=aw-bucket-export_{}.json",
-                self.inner.buckets.into_keys().next().unwrap()
-            ),
-            false => "attachment; filename=aw-buckets-export.json".to_string(),
-        };
         Response::build()
             .status(Status::Ok)
-            .header(Header::new("Content-Disposition", header_content))
-            .sized_body(body.len(), Cursor::new(body))
-            //.header(ContentType::new("application", "json"))
+            .header(Header::new("Content-Disposition", self.filename))
+            .header(ContentType::JSON)
+            .streamed_body(rocket::tokio::fs::File::from_std(self.file))
             .ok()
     }
 }

--- a/aw-server/tests/api.rs
+++ b/aw-server/tests/api.rs
@@ -29,6 +29,49 @@ mod api_tests {
     }
 
     #[test]
+    fn export_includes_pending_writes_and_preserves_headers_and_missing_bucket_errors() {
+        let server = setup_testserver();
+        let datastore = server
+            .state::<endpoints::ServerState>()
+            .unwrap()
+            .datastore
+            .clone();
+        let bucket: Bucket = serde_json::from_value(json!({
+            "id": "live", "type": "test", "client": "test", "hostname": "test"
+        }))
+        .unwrap();
+        datastore.create_bucket(&bucket).unwrap();
+        let event = aw_models::Event::default();
+        let inserted = datastore.insert_events("live", &[event]).unwrap();
+        // No force_commit: exports must see writes acknowledged by the worker.
+        let client = Client::untracked(server).unwrap();
+        for path in ["/api/0/export", "/api/0/buckets/live/export"] {
+            let response = client
+                .get(path)
+                .header(Header::new("Host", "127.0.0.1:5600"))
+                .dispatch();
+            assert_eq!(response.status(), Status::Ok);
+            assert_eq!(response.content_type(), Some(ContentType::JSON));
+            assert_eq!(
+                response.headers().get_one("Content-Disposition"),
+                Some("attachment; filename=aw-bucket-export_live.json")
+            );
+            let body: Value = serde_json::from_str(&response.into_string().unwrap()).unwrap();
+            assert_eq!(
+                body["buckets"]["live"]["events"],
+                serde_json::to_value(&inserted).unwrap()
+            );
+        }
+        let response = client
+            .get("/api/0/buckets/missing/export")
+            .header(Header::new("Host", "127.0.0.1:5600"))
+            .dispatch();
+        assert_eq!(response.status(), Status::NotFound);
+        let body: Value = serde_json::from_str(&response.into_string().unwrap()).unwrap();
+        assert!(body["message"].as_str().unwrap().contains("does not exist"));
+    }
+
+    #[test]
     fn test_bucket() {
         let server = setup_testserver();
         let client = Client::untracked(server).expect("valid instance");


### PR DESCRIPTION
HTTP exports currently hold every event and then a complete JSON string in memory. Serialize event rows incrementally through the existing datastore worker into a private temporary file, then serve that file as the response body. This preserves visibility of acknowledged, uncommitted writes and allows database/serialization/write failures to return an HTTP error before a download begins.

Both single-bucket and all-bucket exports retain the JSON format and download naming. The export query explicitly uses the ordered starttime index, avoiding an unbounded sort even if additional indexes exist.

Part of #671 (HTTP export memory). ActivityWatch/aw-android#229 fixes WebView download saving; this PR addresses the separate Rust HTTP buffering path.

Validation:
- `cargo test -p aw-datastore --lib` and `cargo test -p aw-server`: export serialization/error tests and all server/API tests pass.
- Regression coverage compares JSON with the previous materialized format, including empty buckets, tied timestamps, clipping, nested/Unicode payloads, corrupt rows, writer failure, missing buckets, response headers, and acknowledged writes before commit.
- Added `export_memory`, a reproducible example using only synthetic in-memory data. On 100,000 events with 256-character titles, `/usr/bin/time -l` measured peak RSS of 203,177,984 bytes for materialization versus 54,788,096 bytes for incremental serialization. This includes the in-memory input database and excludes temporary-file I/O; it measures the serialization memory reduction, not HTTP throughput.
- No live database or running server was used for tests or profiling.

Tradeoffs: the completed JSON export occupies temporary disk space (plaintext, with private-file permissions) until the response is dropped. The datastore worker remains occupied while the snapshot is serialized; this PR does not introduce parallel readers or change the consistency contract discussed in #646.
